### PR TITLE
aminoacidChange name => aminoacidChange

### DIFF
--- a/models/json/beacon-v2-default-model/genomicVariations/endpoints.json
+++ b/models/json/beacon-v2-default-model/genomicVariations/endpoints.json
@@ -11,7 +11,7 @@
             "aminoacidChange": {
                 "example": "V600E",
                 "in": "query",
-                "name": "aminoacidchange",
+                "name": "aminoacidChange",
                 "schema": {
                     "type": "string"
                 }

--- a/models/src/beacon-v2-default-model/genomicVariations/endpoints.yaml
+++ b/models/src/beacon-v2-default-model/genomicVariations/endpoints.yaml
@@ -270,7 +270,7 @@ components:
         type: string
       example: BRAF
     aminoacidChange:
-      name: aminoacidchange
+      name: aminoacidChange
       in: query
       schema:
         type: string


### PR DESCRIPTION
There was the odd use of `aminoacidchange` as name for aminoacidChange in endpoints ...

This is a transfer from the old models repo https://github.com/ga4gh-beacon/beacon-v2-Models/pull/118