### PR TITLE
Unify non-standard separate pipeline fields in analysis

### DIFF
--- a/models/json/beacon-v2-default-model/analyses/defaultSchema.json
+++ b/models/json/beacon-v2-default-model/analyses/defaultSchema.json
@@ -40,19 +40,21 @@
         "info": {
             "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/Info"
         },
-        "pipelineName": {
-            "description": "Analysis pipeline and version if a standardized pipeline was used",
+        "pipelineInfo": {
+            "$ref": "../common/externalReference.json",
+            "description": "Public or local pipeline identifier with version, as well as link and notes",
             "examples": [
-                "Pipeline-panel-0001-v1"
-            ],
-            "type": "string"
-        },
-        "pipelineRef": {
-            "description": "Link to Analysis pipeline resource",
-            "examples": [
-                "https://doi.org/10.48511/workflowhub.workflow.111.1"
-            ],
-            "type": "string"
+                {
+                    "id": "Pipeline-panel-0001-v1",
+                    "notes": "Higly customized workflow. Please contact us at dev/null.",
+                    "reference": "https://doi.org/10.48511/workflowhub.workflow.111.1"
+                },
+                {
+                    "id": "aroma.affymetrix",
+                    "notes": "The aroma.affymetrix package is an R package for analyzing small to extremely large Affymetrix data sets.",
+                    "reference": "http://www.aroma-project.org"
+                }
+            ]
         },
         "runId": {
             "description": "Run identifier (external accession or internal ID).",

--- a/models/src/beacon-v2-default-model/analyses/defaultSchema.yaml
+++ b/models/src/beacon-v2-default-model/analyses/defaultSchema.yaml
@@ -29,17 +29,20 @@ properties:
     type: string
     format: date
     examples:
-      - '2021-10-17'
-  pipelineName:
-    description: Analysis pipeline and version if a standardized pipeline was used
-    type: string
+      - 2021-10-17
+  pipelineInfo:
+    description: >-
+      Public or local pipeline identifier with version, as well as link and notes
+    $ref: ../common/externalReference.json
     examples:
-      - Pipeline-panel-0001-v1
-  pipelineRef:
-    description: Link to Analysis pipeline resource
-    type: string
-    examples:
-      - https://doi.org/10.48511/workflowhub.workflow.111.1
+      - id: Pipeline-panel-0001-v1
+        reference: https://doi.org/10.48511/workflowhub.workflow.111.1
+        notes: Higly customized workflow. Please contact us at dev/null.
+      - id: aroma.affymetrix
+        reference: http://www.aroma-project.org
+        notes: >-
+          The aroma.affymetrix package is an R package for analyzing small to
+          extremely large Affymetrix data sets.
   aligner:
     description: Reference to mapping/alignment software
     type: string


### PR DESCRIPTION
This unifies the non-standard separate pipeline fields into the standard externalReference format
Transfer from https://github.com/ga4gh-beacon/beacon-v2-Models/pull/119