### PR TITLE
Create FilteringTerm entity

### DIFF
--- a/framework/json/requests/filteringTerms.json
+++ b/framework/json/requests/filteringTerms.json
@@ -61,6 +61,19 @@
             ],
             "type": "object"
         },
+        "FilteringTerm": {
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/OntologyFilter"
+                },
+                {
+                    "$ref": "#/definitions/AlphanumericFilter"
+                },
+                {
+                    "$ref": "#/definitions/CustomFilter"
+                }
+            ]
+        },
         "OntologyFilter": {
             "description": "Filter results to include records that contain a specific ontology term.",
             "properties": {
@@ -99,17 +112,7 @@
     },
     "description": "Filtering terms are the main means to select subsets of records from a Beacon response. While the name implies the application to a generated response, in practice implementations may apply them at the query stage. Note: In the processing of Beacon v2.0 requests multiple filters are assumed to be chained by the logical AND operator.",
     "items": {
-        "anyOf": [
-            {
-                "$ref": "#/definitions/OntologyFilter"
-            },
-            {
-                "$ref": "#/definitions/AlphanumericFilter"
-            },
-            {
-                "$ref": "#/definitions/CustomFilter"
-            }
-        ]
+        "$ref": "#/definitions/FilteringTerm"
     },
     "title": "Filtering Term Element",
     "type": "array"

--- a/framework/src/requests/filteringTerms.yaml
+++ b/framework/src/requests/filteringTerms.yaml
@@ -8,11 +8,13 @@ description: >-
   to be chained by the logical AND operator.
 type: array
 items:
-  anyOf:
-    - $ref: '#/definitions/OntologyFilter'
-    - $ref: '#/definitions/AlphanumericFilter'
-    - $ref: '#/definitions/CustomFilter'
+  $ref: '#/definitions/FilteringTerm'
 definitions:
+  FilteringTerm:
+    anyOf:
+      - $ref: '#/definitions/OntologyFilter'
+      - $ref: '#/definitions/AlphanumericFilter'
+      - $ref: '#/definitions/CustomFilter'  
   OntologyFilter:
     type: object
     description: Filter results to include records that contain a specific ontology


### PR DESCRIPTION
The current definition just provides the multiple for `filteringTerms`, as an array populated by the selected types (i.e. OntologyFilter, AlphanumericFilter, CustomFilter). However, (AFAIK) the proper way would be to define a `FilteringTerm` prototype which can be one of those instances; otherwise there is no `FilteringTerm` as a concept.
This PR introduces the `FilteringTerm` object as a wrapper for individual instances. In principle this should be a non-breaking change.