### PR TITLE
moving CURIE to beaconCommonComponents

### DIFF
--- a/framework/json/common/beaconCommonComponents.json
+++ b/framework/json/common/beaconCommonComponents.json
@@ -39,6 +39,17 @@
             "example": "org.example.beacon.v2",
             "type": "string"
         },
+        "CURIE": {
+            "description": "A CURIE identifier, e.g. as `id` for an ontology term.",
+            "examples": [
+                "ga4gh:GA.01234abcde",
+                "DUO:0000004",
+                "orcid:0000-0003-3463-0775",
+                "PMID:15254584"
+            ],
+            "pattern": "^\\w[^:]+:.+$",
+            "type": "string"
+        },
         "Exists": {
             "description": "Indicator of whether any record was observed in any of the collections queried. This should be non-null.",
             "examples": [

--- a/framework/json/common/ontologyTerm.json
+++ b/framework/json/common/ontologyTerm.json
@@ -1,23 +1,10 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "additionalProperties": true,
-    "definitions": {
-        "CURIE": {
-            "description": "A CURIE identifier for an ontology term.",
-            "examples": [
-                "ga4gh:GA.01234abcde",
-                "DUO:0000004",
-                "orcid:0000-0003-3463-0775",
-                "PMID:15254584"
-            ],
-            "pattern": "^\\w[^:]+:.+$",
-            "type": "string"
-        }
-    },
     "description": "Definition of an ontology term.",
     "properties": {
         "id": {
-            "$ref": "#/definitions/CURIE"
+            "$ref": "./beaconCommonComponents.json#/definitions/CURIE"
         },
         "label": {
             "description": "The text that describes the term. By default it could be the preferred text of the term, but is it acceptable to customize it for a clearer description and understanding of the term in an specific context.",

--- a/framework/src/common/beaconCommonComponents.yaml
+++ b/framework/src/common/beaconCommonComponents.yaml
@@ -14,16 +14,16 @@ definitions:
     description: Refers to the JSON Schema which describes the set of valid attributes
       for this particular document type. This attribute is mostly used in schemas
       that should be tested in Beacon implementations.
+  ApiVersion:
+    description: an API version.
+    type: string
+    example: v2.0
   BeaconId:
     description: the Id of a Beacon. Usually a reversed domain string, but any URI
       is acceptable. The purpose of this attribute is, in the context of a Beacon
       network, to disambiguate responses coming from different Beacons.
     type: string
     example: org.example.beacon.v2
-  ApiVersion:
-    description: an API version.
-    type: string
-    example: v2.0
   BeaconError:
     description: Beacon-specific error.
     type: object
@@ -40,6 +40,15 @@ definitions:
         type: string
         examples:
           - the provided parameters are incomplete. 'xyz' is missing.
+  CURIE:
+    pattern: ^\w[^:]+:.+$
+    type: string
+    description: A CURIE identifier, e.g. as `id` for an ontology term.
+    examples:
+      - ga4gh:GA.01234abcde
+      - DUO:0000004
+      - orcid:0000-0003-3463-0775
+      - PMID:15254584
   ListOfSchemas:
     description: Set of schemas to be used in the response to a request.
     type: array

--- a/framework/src/common/ontologyTerm.yaml
+++ b/framework/src/common/ontologyTerm.yaml
@@ -4,22 +4,12 @@ description: Definition of an ontology term.
 type: object
 properties:
   id:
-    $ref: '#/definitions/CURIE'
+    $ref: './beaconCommonComponents.json#/definitions/CURIE'
   label:
     type: string
     description: The text that describes the term. By default it could be the preferred
       text of the term, but is it acceptable to customize it for a clearer description
       and understanding of the term in an specific context.
-definitions:
-  CURIE:
-    pattern: ^\w[^:]+:.+$
-    type: string
-    description: A CURIE identifier for an ontology term.
-    examples:
-      - ga4gh:GA.01234abcde
-      - DUO:0000004
-      - orcid:0000-0003-3463-0775
-      - PMID:15254584
 required:
   - id
 additionalProperties: true


### PR DESCRIPTION
The existence of CURIE in `ontologyTerm` sees out of place (and as a side effect breaks some schema referencing for enigmatic reasons). Moving this to `beaconCommonComponents` seems logical & should not break any code since so far CURIE is only being used in `ontologyTerm` (though we may extend this...).