### PR TITLE
remove unnecessary requirements in resultSets

### DIFF
--- a/framework/json/responses/sections/beaconResultsets.json
+++ b/framework/json/responses/sections/beaconResultsets.json
@@ -41,9 +41,7 @@
             "required": [
                 "id",
                 "setType",
-                "exists",
-                "resultsCount",
-                "results"
+                "exists"
             ]
         }
     },

--- a/framework/src/responses/sections/beaconResultsets.yaml
+++ b/framework/src/responses/sections/beaconResultsets.yaml
@@ -48,6 +48,4 @@ definitions:
       - id
       - setType
       - exists
-      - resultsCount
-      - results
     additionalProperties: true


### PR DESCRIPTION
This removes the requirements for `resultsCount` and `results` as part of the `beaconResultSets` definitions. Reason:

* enables boolean resultSets, e.g. discerning between individual datasets in a beacon response
* ... and in the same vein enables beacon aggregators to detail boolean or count responses
* the content format of a beacon is defined by its `returnedGranularity`

This seems like a non-breaking no-brainer. It will be followed up by more adjustments specifically aimed at aggregators/networks.