### PR TITLE
adding `isAggregator` flag

### DIFF
--- a/framework/json/common/beaconCommonComponents.json
+++ b/framework/json/common/beaconCommonComponents.json
@@ -138,6 +138,11 @@
             "description": "Placeholder to allow the Beacon to return any additional information that is necessary or could be of interest in relation to the query or the entry returned. It is recommended to encapsulate additional informations in this attribute instead of directly adding attributes at the same level than the others in order to avoid collision in the names of attributes in future versions of the specification.",
             "type": "object"
         },
+        "IsAggregator": {
+            "default": false,
+            "description": "Optional flag to indicate if this beacon aggregates data from several beacon instances.",
+            "type": "boolean"
+        },
         "Limit": {
             "default": 10,
             "description": "Size of the page. Use `0` to return all the results or the maximum allowed by the Beacon, if there is any.",

--- a/framework/json/responses/sections/beaconInformationalResponseMeta.json
+++ b/framework/json/responses/sections/beaconInformationalResponseMeta.json
@@ -12,6 +12,9 @@
             "$ref": "../../common/beaconCommonComponents.json#/definitions/BeaconId",
             "description": "Identifier of the beacon, as defined in `Beacon`."
         },
+        "isAggregator": {
+            "$ref": "../../common/beaconCommonComponents.json#/definitions/IsAggregator"
+        },
         "returnedSchemas": {
             "$ref": "../../common/beaconCommonComponents.json#/definitions/ListOfSchemas"
         }

--- a/framework/json/responses/sections/beaconResponseMeta.json
+++ b/framework/json/responses/sections/beaconResponseMeta.json
@@ -10,6 +10,9 @@
             "$ref": "../../common/beaconCommonComponents.json#/definitions/BeaconId",
             "description": "Identifier of the beacon instance."
         },
+        "isAggregator": {
+            "$ref": "../../common/beaconCommonComponents.json#/definitions/IsAggregator"
+        },
         "receivedRequestSummary": {
             "$ref": "./beaconReceivedRequestSummary.json",
             "description": "Section of the response that summarize the request received as it has been interpreted by the Beacon server."

--- a/framework/json/responses/sections/beaconResultsets.json
+++ b/framework/json/responses/sections/beaconResultsets.json
@@ -36,6 +36,10 @@
                     "default": "dataset",
                     "description": "Entry type of resultSet. It SHOULD MATCH an entry type declared as collection in the Beacon configuration.",
                     "type": "string"
+                },
+                "sourceBeaconId": {
+                    "$ref": "../../common/beaconCommonComponents.json#/definitions/BeaconId",
+                    "description": "Optional identifier of the beacon this resultSet was collected from, especially for use in beacon aggregators."
                 }
             },
             "required": [

--- a/framework/src/common/beaconCommonComponents.yaml
+++ b/framework/src/common/beaconCommonComponents.yaml
@@ -24,6 +24,12 @@ definitions:
       network, to disambiguate responses coming from different Beacons.
     type: string
     example: org.example.beacon.v2
+  IsAggregator:
+    description: >-
+      Optional flag to indicate if this beacon aggregates data from several
+      beacon instances.
+    type: boolean
+    default: false
   BeaconError:
     description: Beacon-specific error.
     type: object

--- a/framework/src/responses/sections/beaconInformationalResponseMeta.yaml
+++ b/framework/src/responses/sections/beaconInformationalResponseMeta.yaml
@@ -8,6 +8,8 @@ properties:
   apiVersion:
     description: Version of the API.
     $ref: ../../common/beaconCommonComponents.yaml#/definitions/ApiVersion
+  isAggregator:
+    $ref: ../../common/beaconCommonComponents.yaml#/definitions/IsAggregator
   returnedSchemas:
     $ref: ../../common/beaconCommonComponents.yaml#/definitions/ListOfSchemas
 $comment: 'TO REVIEW: the required properties below results in a warning in the example.'

--- a/framework/src/responses/sections/beaconResponseMeta.yaml
+++ b/framework/src/responses/sections/beaconResponseMeta.yaml
@@ -13,6 +13,8 @@ properties:
     $ref: ../../common/beaconCommonComponents.yaml#/definitions/ApiVersion
   returnedSchemas:
     $ref: ../../common/beaconCommonComponents.yaml#/definitions/ListOfSchemas
+  isAggregator:
+    $ref: ../../common/beaconCommonComponents.yaml#/definitions/IsAggregator
   returnedGranularity:
     description: >-
       Granularity of the Beacon response. Targeted Beacon could respond or not with

--- a/framework/src/responses/sections/beaconResultsets.yaml
+++ b/framework/src/responses/sections/beaconResultsets.yaml
@@ -20,6 +20,11 @@ definitions:
         description: id of the resultset
         type: string
         example: datasetA
+      sourceBeaconId:
+        description: >-
+          Optional identifier of the beacon this resultSet was collected from,
+          especially for use in beacon aggregators.
+        $ref: ../../common/beaconCommonComponents.yaml#/definitions/BeaconId
       setType:
         description: Entry type of resultSet. It SHOULD MATCH an entry type declared
           as collection in the Beacon configuration.


### PR DESCRIPTION
This commit adds an optional `isAggregator` flag to `beaconResponseMeta` which will allow especially aggregators to avoid duplications & loops.