### PR TITLE
add beaconId property to the resultSets.

### DIFF
--- a/framework/json/responses/sections/beaconResultsets.json
+++ b/framework/json/responses/sections/beaconResultsets.json
@@ -36,6 +36,10 @@
                     "default": "dataset",
                     "description": "Entry type of resultSet. It SHOULD MATCH an entry type declared as collection in the Beacon configuration.",
                     "type": "string"
+                },
+                "beaconId": {
+                    "$ref": "../../common/beaconCommonComponents.json#/definitions/BeaconId",
+                    "description": "The Id of a Beacon that generated this result."
                 }
             },
             "required": [


### PR DESCRIPTION
This property is optional and make sense in the beacon aggregator response to inform about origin of each resultset returned.