### PR TITLE
Clean up entity to entry type

### DIFF
--- a/framework/src/common/beaconCommonComponents.yaml
+++ b/framework/src/common/beaconCommonComponents.yaml
@@ -137,7 +137,6 @@ definitions:
 
       * `boolean`: returns true/false' responses
       * `count`: adds the total number of positive results found
-      * `aggregated`: returns summary, aggregated or distribution like responses
       * `record`: returns details for every row. In cases where a Beacon prefers
       to return records with fewer than allattributes, different strategies have
       to be considered w/o adding them to the current design, e.g.:
@@ -147,7 +146,6 @@ definitions:
     enum:
       - boolean
       - count
-      - aggregated
       - record
     default: boolean
   TestMode:


### PR DESCRIPTION
Harmonizing "entity" mentions to "entry types".
This changes *break* the current implementations as it affects the definition of the references to entry types supported schemas.
CAVEAT: this branch was expected to build on top of "clean-up", not "main". I'll try to amend that in the PR process.