### PR TITLE
proposing "warnings" for response meta

### DIFF
--- a/framework/json/responses/sections/beaconResponseMeta.json
+++ b/framework/json/responses/sections/beaconResponseMeta.json
@@ -21,6 +21,11 @@
         },
         "testMode": {
             "$ref": "../../common/beaconCommonComponents.json#/definitions/TestMode"
+        },
+        "warnings": {
+            "description": "A list of \"warnings\", _i.e._ messages from the beacon about potential problems such as request parameters that could not be parsed or the reasons for a mismatch between request and response granularity.",
+            "items": "string",
+            "type": "array"
         }
     },
     "required": [

--- a/framework/src/responses/sections/beaconResponseMeta.yaml
+++ b/framework/src/responses/sections/beaconResponseMeta.yaml
@@ -24,6 +24,13 @@ properties:
     $ref: ../../common/beaconCommonComponents.yaml#/definitions/TestMode
   receivedRequestSummary:
     $ref: ./beaconReceivedRequestSummary.yaml
+  warnings:
+    description: >-
+      A list of "warnings", _i.e._ messages from the beacon about potential
+      problems such as request parameters that could not be parsed or the reasons
+      for a mismatch between request and response granularity.
+    type: array
+    items: string
 required:
   - beaconId
   - apiVersion


### PR DESCRIPTION
Warnings seem like a much needed item to understand responses where the server wants to indicate information about potential problems with the response which are not outright failures. Especially useful for debugging aggregators.