### PR TITLE
received filters in summary to object

### DIFF
--- a/framework/json/common/filteringTerms.json
+++ b/framework/json/common/filteringTerms.json
@@ -1,15 +1,39 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "additionalProperties": true,
     "definitions": {
+        "FilteringTerm": {
+            "title": "Filtering Term Element",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "description": "Custom filter terms should contain a unique identifier.",
+                    "examples": [ "demographic.ethnicity:asian" ],
+                    "type": "string"
+                },
+                "scope": {
+                    "description": "The entry type to which the filter applies",
+                    "examples": [ "biosamples" ],
+                    "type": "string"
+                }
+            },
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/OntologyFilter"
+                },
+                {
+                    "$ref": "#/definitions/AlphanumericFilter"
+                },
+                {
+                    "$ref": "#/definitions/CustomFilter"
+                }
+            ],
+            "required": [
+                "id"
+            ]
+        },
         "AlphanumericFilter": {
             "description": "Filter results based on operators and values applied to alphanumeric fields.",
             "properties": {
-                "id": {
-                    "description": "Field identfier to be queried.",
-                    "example": "age",
-                    "type": "string"
-                },
                 "operator": {
                     "default": "=",
                     "description": "Defines how the value relates to the field `id`.",
@@ -21,22 +45,16 @@
                         ">=",
                         "<="
                     ],
-                    "example": ">",
-                    "type": "string"
-                },
-                "scope": {
-                    "description": "The entry type to which the filter applies",
-                    "example": "biosamples",
+                    "examples": [ ">" ],
                     "type": "string"
                 },
                 "value": {
                     "description": "Alphanumeric search term to be used within the query which can contain wildcard characters (%) to denote any number of unknown characters.  Values can be assocatied with units if applicable.",
-                    "example": "P70Y",
+                    "examples": [ "P70Y" ],
                     "type": "string"
                 }
             },
             "required": [
-                "id",
                 "operator",
                 "value"
             ],
@@ -44,53 +62,15 @@
         },
         "CustomFilter": {
             "description": "Filter results to include records that contain a custom term defined by this Beacon.",
-            "properties": {
-                "id": {
-                    "description": "Custom filter terms should contain a unique identifier.",
-                    "example": "demographic.ethnicity:asian",
-                    "type": "string"
-                },
-                "scope": {
-                    "description": "The entry type to which the filter applies",
-                    "example": "biosamples",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "id"
-            ],
             "type": "object"
-        },
-        "FilteringTerm": {
-            "anyOf": [
-                {
-                    "$ref": "#/definitions/OntologyFilter"
-                },
-                {
-                    "$ref": "#/definitions/AlphanumericFilter"
-                },
-                {
-                    "$ref": "#/definitions/CustomFilter"
-                }
-            ]
         },
         "OntologyFilter": {
             "description": "Filter results to include records that contain a specific ontology term.",
             "properties": {
-                "id": {
-                    "description": "Term ID to be queried, using CURIE syntax where possible.",
-                    "example": "HP:0002664",
-                    "type": "string"
-                },
                 "includeDescendantTerms": {
                     "default": true,
                     "description": "Define if the Beacon should implement the ontology hierarchy, thus query the descendant terms of `id`.",
                     "type": "boolean"
-                },
-                "scope": {
-                    "description": "The entry type to which the filter applies",
-                    "example": "biosamples",
-                    "type": "string"
                 },
                 "similarity": {
                     "default": "exact",
@@ -104,16 +84,13 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "id"
-            ],
             "type": "object"
         }
     },
     "description": "Filtering terms are the main means to select subsets of records from a Beacon response. While the name implies the application to a generated response, in practice implementations may apply them at the query stage. Note: In the processing of Beacon v2.0 requests multiple filters are assumed to be chained by the logical AND operator.",
+    "title": "Filtering Term Element",
+    "type": "array",
     "items": {
         "$ref": "#/definitions/FilteringTerm"
-    },
-    "title": "Filtering Term Element",
-    "type": "array"
+    }
 }

--- a/framework/json/requests/beaconRequestBody.json
+++ b/framework/json/requests/beaconRequestBody.json
@@ -5,7 +5,7 @@
             "description": "Parameters to limit the list of returned results.",
             "properties": {
                 "filters": {
-                    "$ref": "./filteringTerms.json",
+                    "$ref": "../common/filteringTerms.json",
                     "description": "Ontology based filters. Using CURIE syntax is encouraged."
                 },
                 "includeResultsetResponses": {

--- a/framework/json/responses/sections/beaconFilteringTermsResults.json
+++ b/framework/json/responses/sections/beaconFilteringTermsResults.json
@@ -31,8 +31,8 @@
                 }
             },
             "required": [
-                "type",
-                "id"
+                "id",
+                "type"
             ],
             "type": "object"
         },

--- a/framework/json/responses/sections/beaconReceivedRequestSummary.json
+++ b/framework/json/responses/sections/beaconReceivedRequestSummary.json
@@ -7,7 +7,7 @@
             "description": "API version expected by the client to be supported by the server and used in the response format."
         },
         "filters": {
-            "$ref": "../../common/beaconCommonComponents.json#/definitions/Filters",
+            "$ref": "../../common/filteringTerms.json",
             "description": "Filters as submitted in the request."
         },
         "includeResultsetResponses": {

--- a/framework/src/common/filteringTerms.yaml
+++ b/framework/src/common/filteringTerms.yaml
@@ -11,21 +11,28 @@ items:
   $ref: '#/definitions/FilteringTerm'
 definitions:
   FilteringTerm:
-    anyOf:
-      - $ref: '#/definitions/OntologyFilter'
-      - $ref: '#/definitions/AlphanumericFilter'
-      - $ref: '#/definitions/CustomFilter'  
-  OntologyFilter:
-    type: object
-    description: Filter results to include records that contain a specific ontology
-      term.
-    required:
-      - id
     properties:
       id:
         type: string
         description: Term ID to be queried, using CURIE syntax where possible.
-        example: HP:0002664
+        examples: 
+          - HP:0002664
+      scope:
+        type: string
+        description: The entry type to which the filter applies
+        examples:
+          - biosamples
+    anyOf:
+      - $ref: '#/definitions/OntologyFilter'
+      - $ref: '#/definitions/AlphanumericFilter'
+      - $ref: '#/definitions/CustomFilter'  
+    required:
+      - id
+  OntologyFilter:
+    type: object
+    description: Filter results to include records that contain a specific ontology
+      term.
+    properties:
       includeDescendantTerms:
         type: boolean
         default: true
@@ -43,23 +50,14 @@ definitions:
           exactly, but do match to a certain degree of similarity. The Beacon defines
           the semantic similarity model implemented and how to apply the thresholds
           of 'high', 'medium' and 'low' similarity.
-      scope:
-        type: string
-        description: The entry type to which the filter applies
-        example: biosamples
   AlphanumericFilter:
     description: Filter results based on operators and values applied to alphanumeric
       fields.
     type: object
     required:
-      - id
       - operator
       - value
     properties:
-      id:
-        type: string
-        description: Field identfier to be queried.
-        example: age
       operator:
         type: string
         enum:
@@ -78,23 +76,7 @@ definitions:
           contain wildcard characters (%) to denote any number of unknown characters.  Values
           can be assocatied with units if applicable.
         example: P70Y
-      scope:
-        type: string
-        description: The entry type to which the filter applies
-        example: biosamples
   CustomFilter:
     type: object
     description: Filter results to include records that contain a custom term defined
       by this Beacon.
-    required:
-      - id
-    properties:
-      id:
-        type: string
-        description: Custom filter terms should contain a unique identifier.
-        example: demographic.ethnicity:asian
-      scope:
-        type: string
-        description: The entry type to which the filter applies
-        example: biosamples
-additionalProperties: true

--- a/framework/src/requests/beaconRequestBody.yaml
+++ b/framework/src/requests/beaconRequestBody.yaml
@@ -26,7 +26,7 @@ definitions:
       filters:
         description: >-
           Ontology based filters. Using CURIE syntax is encouraged.
-        $ref: ./filteringTerms.yaml
+        $ref: ../common/filteringTerms.yaml
       includeResultsetResponses:
         $ref: ../common/beaconCommonComponents.yaml#/definitions/IncludeResultsetResponses
       pagination:

--- a/framework/src/responses/sections/beaconFilteringTermsResults.yaml
+++ b/framework/src/responses/sections/beaconFilteringTermsResults.yaml
@@ -17,8 +17,8 @@ definitions:
     description: >-
       Entities can be filtered using this term.
     required:
-      - type
       - id
+      - type
     properties:
       type:
         type: string

--- a/framework/src/responses/sections/beaconReceivedRequestSummary.yaml
+++ b/framework/src/responses/sections/beaconReceivedRequestSummary.yaml
@@ -23,7 +23,7 @@ properties:
   filters:
     description: >-
       Filters as submitted in the request.
-    $ref: ../../common/beaconCommonComponents.yaml#/definitions/Filters
+    $ref: ../../common/filteringTerms.yaml
   requestParameters:
     description: >-
       Dictionary of request parameters received in the `RequestBody` or as part


### PR DESCRIPTION
There is an incoherence formats of filters submitted to the query and reported to be submitted:

["request summary"](https://github.com/redmitry/beacon-v2/blob/e8725f8930051fe5cd3c893233fd66b74c5713b2/framework/json/responses/sections/beaconReceivedRequestSummary.json#L9C15-L9C15) vs ["submitted"](https://github.com/redmitry/beacon-v2/blob/e8725f8930051fe5cd3c893233fd66b74c5713b2/framework/json/requests/beaconRequestBody.json#L8).

This pull request is to use the same filteringTerms format (object) in the beaconReceivedRequestSummary.

N.B. This would change 2.0 spec.

D.

