### PR TITLE
add scopes[] to the FilteringTerm

### DIFF
--- a/framework/json/responses/sections/beaconFilteringTermsResults.json
+++ b/framework/json/responses/sections/beaconFilteringTermsResults.json
@@ -28,6 +28,16 @@
                         "alphanumeric"
                     ],
                     "type": "string"
+                },
+                "scopes": {
+                    "description": "Entry types this filter may be applied to.",
+                    "examples": [
+                        "[\"individual\", \"biosample\"]"
+                    ],
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 }
             },
             "required": [

--- a/framework/src/responses/sections/beaconFilteringTermsResults.yaml
+++ b/framework/src/responses/sections/beaconFilteringTermsResults.yaml
@@ -46,6 +46,14 @@ definitions:
         examples:
           - 'B Lymphoblastic Leukemia/Lymphoma'
           - 'Aplasia/Hypoplasia of the middle ear'
+      scopes:
+        description: >- 
+          Entry types this filter may be applied to.
+        examples:
+          - '["individual", "biosample"]'
+        type: array
+        items:
+          type: string
   Resource:
     type: object
     description: >-


### PR DESCRIPTION
The patch is the response to the several discussions #93, #94.

[beaconFilteringTermsResults.json](https://github.com/ga4gh-beacon/beacon-v2/blob/d2be0e2fcc4cbbaebb355caaf8a20af25504a687/framework/json/responses/sections/beaconFilteringTermsResults.json#L5) FilteringTerm should provide a list of scopes (entryTypes) the filter may be applied,

Dmitry