### PR TITLE
complexValue required relocated to correct level

### DIFF
--- a/models/json/beacon-v2-default-model/common/complexValue.json
+++ b/models/json/beacon-v2-default-model/common/complexValue.json
@@ -38,9 +38,9 @@
                 "$ref": "#/definitions/TypedQuantity"
             },
             "type": "array"
-        },
-        "required": [ "typedQuantities" ]
+        }
     },
+    "required": [ "typedQuantities" ],
     "title": "Complex Value",
     "type": "object"
 }


### PR DESCRIPTION
While I was validating my beacon, I encountered this issue with complexValue. My validator detected that complexValue.json was not any different than [value.json](https://github.com/ga4gh-beacon/beacon-v2/blob/main/models/json/beacon-v2-default-model/common/value.json) because [complexValue.json](https://github.com/ga4gh-beacon/beacon-v2/blob/main/models/json/beacon-v2-default-model/common/complexValue.json) didn't point correctly the required fields needed.
This commit is a hotfix to ammend this quickly to be able to continue regular beacon validations.