### PR TITLE
Hot Fix to align with json

### DIFF
--- a/models/src/beacon-v2-default-model/common/complexValue.yaml
+++ b/models/src/beacon-v2-default-model/common/complexValue.yaml
@@ -9,8 +9,8 @@ properties:
     type: array
     items:
       $ref: '#/definitions/TypedQuantity'
-  required:
-    - typedQuantities
+required:
+  - typedQuantities
 
 definitions:
   TypedQuantity:


### PR DESCRIPTION
The last fix for the wrong level of `required` was only done in json... Please always add `src` first since (well, both).