### PR TITLE
Definitions to $defs

### DIFF
--- a/bin/beaconYamler.py
+++ b/bin/beaconYamler.py
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python3
+#!/usr/bin/env python3
 
 import sys, re, json
 import pathlib

--- a/bin/deref_schemas/biosamples/defaultSchema.yaml
+++ b/bin/deref_schemas/biosamples/defaultSchema.yaml
@@ -260,7 +260,7 @@ properties:
               title: Value
               type: object
             - $schema: https://json-schema.org/draft/2020-12/schema
-              definitions:
+              $defs:
                 TypedQuantity:
                   properties:
                     quantity:
@@ -1064,7 +1064,7 @@ properties:
     description: List of phenotypic abnormalities of the sample. RECOMMENDED.
     items:
       $schema: https://json-schema.org/draft/2020-12/schema
-      definitions: {}
+      $defs: {}
       description: Used to describe a phenotype that characterizes the subject or biosample.
       properties:
         evidence:

--- a/bin/deref_schemas/cohorts/defaultSchema.yaml
+++ b/bin/deref_schemas/cohorts/defaultSchema.yaml
@@ -2,7 +2,7 @@
 $comment: 'version: ga4gh-beacon-cohort-v2.0.0'
 $schema: https://json-schema.org/draft/2020-12/schema
 additionalProperties: &1 !!perl/scalar:JSON::PP::Boolean 1
-definitions:
+$defs:
   CohortCriteria:
     description: Criteria used for defining the cohort. It is assumed that all cohort participants will match or NOT match such criteria.
     properties:
@@ -366,7 +366,7 @@ definitions:
         description: Phenotypic condition(s) in cohort inclusion criteria
         items:
           $schema: https://json-schema.org/draft/2020-12/schema
-          definitions: {}
+          $defs: {}
           description: Used to describe a phenotype that characterizes the subject or biosample.
           properties:
             evidence:
@@ -1660,7 +1660,7 @@ properties:
         description: Phenotypic condition(s) in cohort inclusion criteria
         items:
           $schema: https://json-schema.org/draft/2020-12/schema
-          definitions: {}
+          $defs: {}
           description: Used to describe a phenotype that characterizes the subject or biosample.
           properties:
             evidence:
@@ -2406,7 +2406,7 @@ properties:
         description: Phenotypic condition(s) in cohort inclusion criteria
         items:
           $schema: https://json-schema.org/draft/2020-12/schema
-          definitions: {}
+          $defs: {}
           description: Used to describe a phenotype that characterizes the subject or biosample.
           properties:
             evidence:

--- a/bin/deref_schemas/datasets/defaultSchema.yaml
+++ b/bin/deref_schemas/datasets/defaultSchema.yaml
@@ -13,7 +13,7 @@ properties:
   dataUseConditions:
     $schema: https://json-schema.org/draft/2020-12/schema
     additionalProperties: 1
-    definitions:
+    $defs:
       DUODataUse:
         allOf:
           - description: 'Data Use Ontology codes and additional information associated with a data object (e.g. sample, dataset).'

--- a/bin/deref_schemas/genomicVariations/defaultSchema.yaml
+++ b/bin/deref_schemas/genomicVariations/defaultSchema.yaml
@@ -2,7 +2,7 @@
 $comment: 'version: ga4gh-beacon-variant-v2.0.0'
 $schema: https://json-schema.org/draft/2020-12/schema
 additionalProperties: &1 !!perl/scalar:JSON::PP::Boolean 1
-definitions:
+$defs:
   CaseLevelVariant:
     description: ''
     properties:

--- a/bin/deref_schemas/individuals/defaultSchema.yaml
+++ b/bin/deref_schemas/individuals/defaultSchema.yaml
@@ -739,7 +739,7 @@ properties:
               title: Value
               type: object
             - $schema: https://json-schema.org/draft/2020-12/schema
-              definitions:
+              $defs:
                 TypedQuantity:
                   properties:
                     quantity:
@@ -1299,7 +1299,7 @@ properties:
     items:
       $schema: https://json-schema.org/draft/2020-12/schema
       additionalProperties: 1
-      definitions:
+      $defs:
         pedigreeMember:
           examples:
             - membersInProband:
@@ -1696,7 +1696,7 @@ properties:
   phenotypicFeatures:
     items:
       $schema: https://json-schema.org/draft/2020-12/schema
-      definitions: {}
+      $defs: {}
       description: Used to describe a phenotype that characterizes the subject or biosample.
       properties:
         evidence:

--- a/bin/deref_schemas/obj/Complex Value.yaml
+++ b/bin/deref_schemas/obj/Complex Value.yaml
@@ -1,7 +1,7 @@
 ---
 Complex Value:
   $schema: https://json-schema.org/draft/2020-12/schema
-  definitions:
+  $defs:
     TypedQuantity:
       properties:
         quantity:

--- a/bin/deref_schemas/obj/dataUseConditions.yaml
+++ b/bin/deref_schemas/obj/dataUseConditions.yaml
@@ -2,7 +2,7 @@
 dataUseConditions:
   $schema: https://json-schema.org/draft/2020-12/schema
   additionalProperties: 1
-  definitions:
+  $defs:
     DUODataUse:
       allOf:
       - description: Data Use Ontology codes and additional information associated

--- a/bin/deref_schemas/obj/exclusionCriteria.yaml
+++ b/bin/deref_schemas/obj/exclusionCriteria.yaml
@@ -413,7 +413,7 @@ exclusionCriteria:
       description: Phenotypic condition(s) in cohort inclusion criteria
       items:
         $schema: https://json-schema.org/draft/2020-12/schema
-        definitions: {}
+        $defs: {}
         description: Used to describe a phenotype that characterizes the subject or
           biosample.
         properties:

--- a/bin/deref_schemas/obj/inclusionCriteria.yaml
+++ b/bin/deref_schemas/obj/inclusionCriteria.yaml
@@ -413,7 +413,7 @@ inclusionCriteria:
       description: Phenotypic condition(s) in cohort inclusion criteria
       items:
         $schema: https://json-schema.org/draft/2020-12/schema
-        definitions: {}
+        $defs: {}
         description: Used to describe a phenotype that characterizes the subject or
           biosample.
         properties:

--- a/bin/deref_schemas/obj/measurementValue.yaml
+++ b/bin/deref_schemas/obj/measurementValue.yaml
@@ -3,7 +3,7 @@ measurementValue:
   properties:
     Complex Value:
       $schema: https://json-schema.org/draft/2020-12/schema
-      definitions:
+      $defs:
         TypedQuantity:
           properties:
             quantity:

--- a/bin/deref_schemas/obj/measurements.yaml
+++ b/bin/deref_schemas/obj/measurements.yaml
@@ -168,7 +168,7 @@ measurements:
           title: Value
           type: object
         - $schema: https://json-schema.org/draft/2020-12/schema
-          definitions:
+          $defs:
             TypedQuantity:
               properties:
                 quantity:

--- a/bin/deref_schemas/obj/measures.yaml
+++ b/bin/deref_schemas/obj/measures.yaml
@@ -166,7 +166,7 @@ measures:
           title: Value
           type: object
         - $schema: https://json-schema.org/draft/2020-12/schema
-          definitions:
+          $defs:
             TypedQuantity:
               properties:
                 quantity:

--- a/bin/deref_schemas/obj/pedigrees.yaml
+++ b/bin/deref_schemas/obj/pedigrees.yaml
@@ -3,7 +3,7 @@ pedigrees:
   items:
     $schema: https://json-schema.org/draft/2020-12/schema
     additionalProperties: 1
-    definitions:
+    $defs:
       pedigreeMember:
         examples:
         - membersInProband:

--- a/bin/deref_schemas/obj/phenotypicConditions.yaml
+++ b/bin/deref_schemas/obj/phenotypicConditions.yaml
@@ -3,7 +3,7 @@ phenotypicConditions:
   description: Phenotypic condition(s) in cohort inclusion criteria
   items:
     $schema: https://json-schema.org/draft/2020-12/schema
-    definitions: {}
+    $defs: {}
     description: Used to describe a phenotype that characterizes the subject or biosample.
     properties:
       evidence:

--- a/bin/deref_schemas/obj/phenotypicFeatures.yaml
+++ b/bin/deref_schemas/obj/phenotypicFeatures.yaml
@@ -2,7 +2,7 @@
 phenotypicFeatures:
   items:
     $schema: https://json-schema.org/draft/2020-12/schema
-    definitions: {}
+    $defs: {}
     description: Used to describe a phenotype that characterizes the subject or biosample.
     properties:
       evidence:

--- a/framework/json/common/beaconCommonComponents.json
+++ b/framework/json/common/beaconCommonComponents.json
@@ -1,6 +1,5 @@
 {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "definitions": {
+    "$defs": {
         "$schema": {
             "$comment": "TO REVIEW: adding a `format` or `regex` attribute that validates correctly against a file path (relative).",
             "description": "Refers to the JSON Schema which describes the set of valid attributes for this particular document type. This attribute is mostly used in schemas that should be tested in Beacon implementations.",
@@ -88,7 +87,7 @@
             "description": "A handover is a typed link for attaching actionable links to results, non purely informational, requests. The goal of the handovers is to list the different actions available, e.g.:\n* a link to a request access page * linking to a file for download, e.g. a VCF file\nAnother common scenario is to provide a fast summary response (e.g. BeconCountResponse) and to provide access to different endpoints for the entities matched by the query using temporary access tokens in the handover URLs.",
             "properties": {
                 "handoverType": {
-                    "$ref": "#/definitions/HandoverType"
+                    "$ref": "#/$defs/HandoverType"
                 },
                 "note": {
                     "description": "An optional text including considerations on the handover link provided.",
@@ -157,7 +156,7 @@
         "ListOfHandovers": {
             "description": "Set of handovers to be added in one section the response.",
             "items": {
-                "$ref": "#/definitions/Handover",
+                "$ref": "#/$defs/Handover",
                 "description": "Requested schema to be used for individuals in the response."
             },
             "type": "array"
@@ -165,7 +164,7 @@
         "ListOfSchemas": {
             "description": "Set of schemas to be used in the response to a request.",
             "items": {
-                "$ref": "#/definitions/SchemasPerEntity"
+                "$ref": "#/$defs/SchemasPerEntity"
             },
             "type": "array"
         },
@@ -191,22 +190,22 @@
             "description": "Pagination to apply or that has been applied on the results.",
             "properties": {
                 "currentPage": {
-                    "$ref": "#/definitions/PageToken",
+                    "$ref": "#/$defs/PageToken",
                     "description": "Token of the returned page. To be used only in the response to allow the client to check if the returned page is the one requested."
                 },
                 "limit": {
-                    "$ref": "#/definitions/Limit"
+                    "$ref": "#/$defs/Limit"
                 },
                 "nextPage": {
-                    "$ref": "#/definitions/PageToken",
+                    "$ref": "#/$defs/PageToken",
                     "description": "Token of the next page. Used to navigate forward. If empty, it is assumed that no more pages are available"
                 },
                 "previousPage": {
-                    "$ref": "#/definitions/PageToken",
+                    "$ref": "#/$defs/PageToken",
                     "description": "Token of the previous page. Used to navigate backwards. If empty, it is assumed that the current page is the first one."
                 },
                 "skip": {
-                    "$ref": "#/definitions/Skip"
+                    "$ref": "#/$defs/Skip"
                 }
             },
             "type": "object"
@@ -243,6 +242,7 @@
             "type": "boolean"
         }
     },
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "description": "Definition of relatively simple components used in different points of the Beacon specification, both in requests and responses, therefore not associated exclusively with one or the other. Separate schema documents are provided for complex components.",
     "title": "Beacon Common Components",
     "type": "object"

--- a/framework/json/common/ontologyTerm.json
+++ b/framework/json/common/ontologyTerm.json
@@ -4,7 +4,7 @@
     "description": "Definition of an ontology term.",
     "properties": {
         "id": {
-            "$ref": "./beaconCommonComponents.json#/definitions/CURIE"
+            "$ref": "./beaconCommonComponents.json#/$defs/CURIE"
         },
         "label": {
             "description": "The text that describes the term. By default it could be the preferred text of the term, but is it acceptable to customize it for a clearer description and understanding of the term in an specific context.",

--- a/framework/json/configuration/beaconConfigurationSchema.json
+++ b/framework/json/configuration/beaconConfigurationSchema.json
@@ -1,7 +1,5 @@
 {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "additionalProperties": true,
-    "definitions": {
+    "$defs": {
         "EntryTypes": {
             "additionalProperties": {
                 "$ref": "./entryTypeDefinition.json",
@@ -12,13 +10,15 @@
             "type": "object"
         }
     },
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": true,
     "description": "Files complaint with this schema are the configuration ones. The details returned in `service-info` are mirroring the ones in this configuration file.",
     "properties": {
         "$schema": {
-            "$ref": "../common/beaconCommonComponents.json#/definitions/$schema"
+            "$ref": "../common/beaconCommonComponents.json#/$defs/$schema"
         },
         "entryTypes": {
-            "$ref": "#/definitions/EntryTypes"
+            "$ref": "#/$defs/EntryTypes"
         },
         "maturityAttributes": {
             "description": "Declares the level of maturity of the Beacon instance.",
@@ -39,7 +39,7 @@
             "description": "Configuration of the security aspects of the Beacon. By default, a Beacon that does not declare the configuration settings would return `boolean` (true/false) responses, and only if the user is authenticated and explicitly authorized to access the Beacon resources. Although this is the safest set of settings, it is not recommended unless the Beacon shares very sensitive information. Non sensitive Beacons should preferably opt for a `record` and `PUBLIC` combination.",
             "properties": {
                 "defaultGranularity": {
-                    "$ref": "../common/beaconCommonComponents.json#/definitions/Granularity",
+                    "$ref": "../common/beaconCommonComponents.json#/$defs/Granularity",
                     "description": "Default granularity. Some responses could return higher detail, but this would be the granularity by default."
                 },
                 "securityLevels": {

--- a/framework/json/configuration/beaconMapSchema.json
+++ b/framework/json/configuration/beaconMapSchema.json
@@ -1,12 +1,10 @@
 {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "additionalProperties": true,
-    "definitions": {
+    "$defs": {
         "Endpoint": {
             "properties": {
                 "endpoints": {
                     "additionalProperties": {
-                        "$ref": "#/definitions/RelatedEndpoint"
+                        "$ref": "#/$defs/RelatedEndpoint"
                     },
                     "description": "Optional. A list describing additional endpoints implemented by this Beacon instance for that entry type. Additional details on the endpoint parameters, supported HTTP verbs, etc. could be obtained by parsing the OpenAPI definition referenced in the `openAPIEndpointsDefinition` attribute.",
                     "minProperties": 0,
@@ -61,14 +59,16 @@
             "type": "object"
         }
     },
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": true,
     "description": "Map of a Beacon, its entry types and endpoints. It isconceptually similar to a website sitemap.",
     "properties": {
         "$schema": {
-            "$ref": "../common/beaconCommonComponents.json#/definitions/$schema"
+            "$ref": "../common/beaconCommonComponents.json#/$defs/$schema"
         },
         "endpointSets": {
             "additionalProperties": {
-                "$ref": "#/definitions/Endpoint"
+                "$ref": "#/$defs/Endpoint"
             },
             "description": "List of enpoints included in this Beacon instance. This is list is meant to inform Beacon clients, e.g. a Beacon Network, about the available endpoints, it is not used to generate any automatic list, but could be used for Beacon validation purposes.",
             "minProperties": 1,

--- a/framework/json/configuration/entryTypeDefinition.json
+++ b/framework/json/configuration/entryTypeDefinition.json
@@ -5,7 +5,7 @@
     "description": "Definition of an element or entry type including the Beacon v2 required and suggested attributes. This schema purpose is to  describe each type of entities included in a Beacon, hence Beacon clients could have some metadata about such entities.\n\nThe `id` attribute is the key that should be used in other parts of the Beacon Model to allow Beacon clients to identify the different parts (e.g. endpoints, filteringTerms, request parameters, etc.) that fully describe an entry type.",
     "properties": {
         "$schema": {
-            "$ref": "../common/beaconCommonComponents.json#/definitions/$schema"
+            "$ref": "../common/beaconCommonComponents.json#/$defs/$schema"
         },
         "aCollectionOf": {
             "description": "If the entry type is a collection of other entry types, (e.g. a Dataset is a collection of Records), then this attribute must list the entry types that could be included. One collection type could be defined as included more than one entry type (e.g. a Dataset could include Individuals or Genomic Variants), in such cases the entries are alternative, meaning that a given instance of this entry type could be of only one of the types (e.g. a given Dataset contains Individuals, while another Dataset could contain Genomic Variants, but not both at once).",
@@ -44,7 +44,7 @@
             "type": "string"
         },
         "nonFilteredQueriesAllowed": {
-            "$ref": "../common/beaconCommonComponents.json#/definitions/NonFilteredQueriesAllowed"
+            "$ref": "../common/beaconCommonComponents.json#/$defs/NonFilteredQueriesAllowed"
         },
         "ontologyTermForThisType": {
             "$comments": "++++++ THIS IS THE END OF THE ontologized element ++++++",

--- a/framework/json/configuration/entryTypesSchema.json
+++ b/framework/json/configuration/entryTypesSchema.json
@@ -1,7 +1,5 @@
 {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "additionalProperties": true,
-    "definitions": {
+    "$defs": {
         "EntryTypes": {
             "additionalProperties": {
                 "$ref": "./entryTypeDefinition.json",
@@ -11,10 +9,12 @@
             "minProperties": 1
         }
     },
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": true,
     "description": "Schema for the Enrty Types list.",
     "properties": {
         "entryTypes": {
-            "$ref": "#/definitions/EntryTypes",
+            "$ref": "#/$defs/EntryTypes",
             "description": "List of entry types."
         }
     },

--- a/framework/json/configuration/filteringTermsSchema.json
+++ b/framework/json/configuration/filteringTermsSchema.json
@@ -1,7 +1,5 @@
 {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "additionalProperties": true,
-    "definitions": {
+    "$defs": {
         "FilterTerm": {
             "properties": {
                 "ftType": {
@@ -47,12 +45,14 @@
             "type": "object"
         }
     },
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": true,
     "description": "Schema for the Filtering Terms list related to the hosting entry type. It is kept separated to allow updating it independently.",
     "properties": {
         "filteringTerms": {
             "description": "List of filtering terms that could be used to filter this concept in this instance of Beacon.",
             "items": {
-                "$ref": "#/definitions/FilterTerm"
+                "$ref": "#/$defs/FilterTerm"
             },
             "minItems": 0,
             "type": "array"

--- a/framework/json/endpoints.json
+++ b/framework/json/endpoints.json
@@ -5,7 +5,7 @@
                 "in": "query",
                 "name": "limit",
                 "schema": {
-                    "$ref": "./common/beaconCommonComponents.json#/definitions/Limit"
+                    "$ref": "./common/beaconCommonComponents.json#/$defs/Limit"
                 }
             },
             "requestedSchema": {
@@ -22,7 +22,7 @@
                 "in": "query",
                 "name": "skip",
                 "schema": {
-                    "$ref": "./common/beaconCommonComponents.json#/definitions/Skip"
+                    "$ref": "./common/beaconCommonComponents.json#/$defs/Skip"
                 }
             }
         },

--- a/framework/json/requests/beaconRequestBody.json
+++ b/framework/json/requests/beaconRequestBody.json
@@ -1,6 +1,5 @@
 {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "definitions": {
+    "$defs": {
         "BeaconQuery": {
             "description": "Parameters to limit the list of returned results.",
             "properties": {
@@ -9,10 +8,10 @@
                     "description": "Ontology based filters. Using CURIE syntax is encouraged."
                 },
                 "includeResultsetResponses": {
-                    "$ref": "../common/beaconCommonComponents.json#/definitions/IncludeResultsetResponses"
+                    "$ref": "../common/beaconCommonComponents.json#/$defs/IncludeResultsetResponses"
                 },
                 "pagination": {
-                    "$ref": "../common/beaconCommonComponents.json#/definitions/Pagination",
+                    "$ref": "../common/beaconCommonComponents.json#/$defs/Pagination",
                     "description": "Pagination parameters applied to response documents, in case of record level granularity."
                 },
                 "requestParameters": {
@@ -20,28 +19,29 @@
                     "description": "Parameters used for the entry type specific query elements."
                 },
                 "requestedGranularity": {
-                    "$ref": "../common/beaconCommonComponents.json#/definitions/Granularity",
+                    "$ref": "../common/beaconCommonComponents.json#/$defs/Granularity",
                     "description": "Requested granularity for the response. Beacons do not have to respond with the requested granularity, e.g. may respond with count results although record level granularity had been requested but indicate the granularity of the response in the response's metadata."
                 },
                 "testMode": {
-                    "$ref": "../common/beaconCommonComponents.json#/definitions/TestMode",
+                    "$ref": "../common/beaconCommonComponents.json#/$defs/TestMode",
                     "description": "Used for indicating that a request or response is done in a test context."
                 }
             },
             "type": "object"
         }
     },
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "description": "Schema for the Beacon request. It is named `RequestBody` to keep the same nomenclature used by OpenAPI v3, but it actually contains the definition of the whole HTTP POST request payload.",
     "properties": {
         "$schema": {
-            "$ref": "../common/beaconCommonComponents.json#/definitions/$schema"
+            "$ref": "../common/beaconCommonComponents.json#/$defs/$schema"
         },
         "meta": {
             "$ref": "./beaconRequestMeta.json",
             "description": "Information relevant for building the response."
         },
         "query": {
-            "$ref": "#/definitions/BeaconQuery"
+            "$ref": "#/$defs/BeaconQuery"
         }
     },
     "required": [

--- a/framework/json/requests/beaconRequestMeta.json
+++ b/framework/json/requests/beaconRequestMeta.json
@@ -3,14 +3,14 @@
     "description": "Meta section of the Beacon request. It includes request context details relevant for the Beacon server when processing the request.",
     "properties": {
         "$schema": {
-            "$ref": "../common/beaconCommonComponents.json#/definitions/$schema"
+            "$ref": "../common/beaconCommonComponents.json#/$defs/$schema"
         },
         "apiVersion": {
-            "$ref": "../common/beaconCommonComponents.json#/definitions/ApiVersion",
+            "$ref": "../common/beaconCommonComponents.json#/$defs/ApiVersion",
             "description": "API version expected by the client to be supported by the server and used in the response format."
         },
         "requestedSchemas": {
-            "$ref": "../common/beaconCommonComponents.json#/definitions/ListOfSchemas",
+            "$ref": "../common/beaconCommonComponents.json#/$defs/ListOfSchemas",
             "description": "Set of schemas to be used in the response."
         }
     },

--- a/framework/json/requests/filteringTerms.json
+++ b/framework/json/requests/filteringTerms.json
@@ -1,7 +1,5 @@
 {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "additionalProperties": true,
-    "definitions": {
+    "$defs": {
         "AlphanumericFilter": {
             "description": "Filter results based on operators and values applied to alphanumeric fields.",
             "properties": {
@@ -64,13 +62,13 @@
         "FilteringTerm": {
             "anyOf": [
                 {
-                    "$ref": "#/definitions/OntologyFilter"
+                    "$ref": "#/$defs/OntologyFilter"
                 },
                 {
-                    "$ref": "#/definitions/AlphanumericFilter"
+                    "$ref": "#/$defs/AlphanumericFilter"
                 },
                 {
-                    "$ref": "#/definitions/CustomFilter"
+                    "$ref": "#/$defs/CustomFilter"
                 }
             ]
         },
@@ -110,9 +108,11 @@
             "type": "object"
         }
     },
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": true,
     "description": "Filtering terms are the main means to select subsets of records from a Beacon response. While the name implies the application to a generated response, in practice implementations may apply them at the query stage. Note: In the processing of Beacon v2.0 requests multiple filters are assumed to be chained by the logical AND operator.",
     "items": {
-        "$ref": "#/definitions/FilteringTerm"
+        "$ref": "#/$defs/FilteringTerm"
     },
     "title": "Filtering Term Element",
     "type": "array"

--- a/framework/json/responses/beaconBooleanResponse.json
+++ b/framework/json/responses/beaconBooleanResponse.json
@@ -3,11 +3,11 @@
     "description": "Complete definition for a minimal response that provides *only* a `Boolean` exists true|false answer.",
     "properties": {
         "beaconHandovers": {
-            "$ref": "../common/beaconCommonComponents.json#/definitions/ListOfHandovers",
+            "$ref": "../common/beaconCommonComponents.json#/$defs/ListOfHandovers",
             "description": "List of handovers that apply to the whole response, not to any resultset or result in particular."
         },
         "info": {
-            "$ref": "../common/beaconCommonComponents.json#/definitions/Info",
+            "$ref": "../common/beaconCommonComponents.json#/$defs/Info",
             "description": "Additional details that could be of interest. Provided to clearly enclose any attribute that is not part of the Beacon specification."
         },
         "meta": {

--- a/framework/json/responses/beaconCollectionsResponse.json
+++ b/framework/json/responses/beaconCollectionsResponse.json
@@ -4,11 +4,11 @@
     "description": "Beacon response that includes details about the collections in this Beacon.",
     "properties": {
         "beaconHandovers": {
-            "$ref": "../common/beaconCommonComponents.json#/definitions/ListOfHandovers",
+            "$ref": "../common/beaconCommonComponents.json#/$defs/ListOfHandovers",
             "description": "List of handovers that apply to the whole response, not to any resultset or result in particular."
         },
         "info": {
-            "$ref": "../common/beaconCommonComponents.json#/definitions/Info",
+            "$ref": "../common/beaconCommonComponents.json#/$defs/Info",
             "description": "Additional details that could be of interest. Provided to clearly enclose any attribute that is not part of the Beacon specification."
         },
         "meta": {

--- a/framework/json/responses/beaconCountResponse.json
+++ b/framework/json/responses/beaconCountResponse.json
@@ -3,11 +3,11 @@
     "description": "Complete definition for a response that does not include record level details but provides `Boolean` and `count` information.",
     "properties": {
         "beaconHandovers": {
-            "$ref": "../common/beaconCommonComponents.json#/definitions/ListOfHandovers",
+            "$ref": "../common/beaconCommonComponents.json#/$defs/ListOfHandovers",
             "description": "List of handovers that apply to the whole response, not to any resultset or result in particular."
         },
         "info": {
-            "$ref": "../common/beaconCommonComponents.json#/definitions/Info",
+            "$ref": "../common/beaconCommonComponents.json#/$defs/Info",
             "description": "Additional details that could be of interest. Provided to clearly enclose any attribute that is not part of the Beacon specification."
         },
         "meta": {

--- a/framework/json/responses/beaconErrorResponse.json
+++ b/framework/json/responses/beaconErrorResponse.json
@@ -4,7 +4,7 @@
     "description": "An unsuccessful operation.",
     "properties": {
         "error": {
-            "$ref": "../common/beaconCommonComponents.json#/definitions/BeaconError"
+            "$ref": "../common/beaconCommonComponents.json#/$defs/BeaconError"
         },
         "meta": {
             "$ref": "./sections/beaconResponseMeta.json"

--- a/framework/json/responses/beaconResultsetsResponse.json
+++ b/framework/json/responses/beaconResultsetsResponse.json
@@ -4,11 +4,11 @@
     "description": "Beacon response that includes record level details, grouped in Resultsets.",
     "properties": {
         "beaconHandovers": {
-            "$ref": "../common/beaconCommonComponents.json#/definitions/ListOfHandovers",
+            "$ref": "../common/beaconCommonComponents.json#/$defs/ListOfHandovers",
             "description": "List of handovers that apply to the whole response, not to any resultset or result in particular."
         },
         "info": {
-            "$ref": "../common/beaconCommonComponents.json#/definitions/Info",
+            "$ref": "../common/beaconCommonComponents.json#/$defs/Info",
             "description": "Additional details that could be of interest. Provided to clearly enclose any attribute that is not part of the Beacon specification."
         },
         "meta": {

--- a/framework/json/responses/ga4gh-service-info-1-0-0-schema.json
+++ b/framework/json/responses/ga4gh-service-info-1-0-0-schema.json
@@ -1,6 +1,5 @@
 {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "definitions": {
+    "$defs": {
         "ServiceType": {
             "description": "Type of a GA4GH service",
             "properties": {
@@ -28,6 +27,7 @@
             "type": "object"
         }
     },
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "description": "A way for a service to describe basic metadata concerning a service alongside a set of capabilities and/or limitations of the service. More information on [GitHub](https://github.com/ga4gh-discovery/ga4gh-service-info/).",
     "properties": {
         "contactUrl": {
@@ -90,7 +90,7 @@
             "type": "object"
         },
         "type": {
-            "$ref": "#/definitions/ServiceType"
+            "$ref": "#/$defs/ServiceType"
         },
         "updatedAt": {
             "description": "Timestamp describing when the service was last updated (RFC 3339 format)",

--- a/framework/json/responses/sections/beaconBooleanResponseSection.json
+++ b/framework/json/responses/sections/beaconBooleanResponseSection.json
@@ -3,7 +3,7 @@
     "description": "Boolean (true/false) response section.",
     "properties": {
         "exists": {
-            "$ref": "../../common/beaconCommonComponents.json#/definitions/Exists"
+            "$ref": "../../common/beaconCommonComponents.json#/$defs/Exists"
         }
     },
     "required": [

--- a/framework/json/responses/sections/beaconCountResponseSection.json
+++ b/framework/json/responses/sections/beaconCountResponseSection.json
@@ -3,10 +3,10 @@
     "description": "Payload definition for the \"count\" response.",
     "properties": {
         "exists": {
-            "$ref": "../../common/beaconCommonComponents.json#/definitions/Exists"
+            "$ref": "../../common/beaconCommonComponents.json#/$defs/Exists"
         },
         "numTotalResults": {
-            "$ref": "../../common/beaconCommonComponents.json#/definitions/NumTotalResults",
+            "$ref": "../../common/beaconCommonComponents.json#/$defs/NumTotalResults",
             "description": "Total number of results."
         }
     },

--- a/framework/json/responses/sections/beaconFilteringTermsResults.json
+++ b/framework/json/responses/sections/beaconFilteringTermsResults.json
@@ -1,7 +1,5 @@
 {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "additionalProperties": true,
-    "definitions": {
+    "$defs": {
         "FilteringTerm": {
             "description": "Entities can be filtered using this term.",
             "properties": {
@@ -21,6 +19,25 @@
                     ],
                     "type": "string"
                 },
+                "scopes": {
+                    "description": "Entry types affected by this filter.",
+                    "examples": [
+                        [
+                            "individual",
+                            "biosample",
+                            "analysis",
+                            "run",
+                            "genomicVariation"
+                        ],
+                        [
+                            "biosample"
+                        ]
+                    ],
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
                 "type": {
                     "description": "Either \"custom\", \"alphanumeric\" or ontology/terminology full name. TODO: An ontology ... with a registered prefix does not need a full name so one may better use CURIE to indicate that the resource can be retrieved from the id. This also will allow to provide an enum here.",
                     "examples": [
@@ -28,17 +45,6 @@
                         "alphanumeric"
                     ],
                     "type": "string"
-                },
-                "scopes": {
-                    "description": "Entry types affected by this filter.",
-                    "examples": [
-                        ["individual", "biosample", "analysis", "run", "genomicVariation"], 
-                        ["biosample"]
-                    ],
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
                 }
             },
             "required": [
@@ -99,17 +105,19 @@
             "type": "object"
         }
     },
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": true,
     "description": "Filtering terms and ontology resources utilised in this Beacon.",
     "properties": {
         "filteringTerms": {
             "items": {
-                "$ref": "#/definitions/FilteringTerm"
+                "$ref": "#/$defs/FilteringTerm"
             },
             "type": "array"
         },
         "resources": {
             "items": {
-                "$ref": "#/definitions/Resource"
+                "$ref": "#/$defs/Resource"
             },
             "type": "array"
         }

--- a/framework/json/responses/sections/beaconInfoResults.json
+++ b/framework/json/responses/sections/beaconInfoResults.json
@@ -1,7 +1,5 @@
 {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "additionalProperties": true,
-    "definitions": {
+    "$defs": {
         "BeaconOrganization": {
             "description": "Organization owning the Beacon.",
             "properties": {
@@ -22,7 +20,7 @@
                     "type": "string"
                 },
                 "info": {
-                    "$ref": "../../common/beaconCommonComponents.json#/definitions/Info",
+                    "$ref": "../../common/beaconCommonComponents.json#/$defs/Info",
                     "description": "Additional unspecified metadata about the host Organization."
                 },
                 "logoUrl": {
@@ -45,6 +43,8 @@
             "type": "object"
         }
     },
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": true,
     "description": "Metadata describing a Beacon instance.",
     "properties": {
         "alternativeUrl": {
@@ -55,7 +55,7 @@
             "type": "string"
         },
         "apiVersion": {
-            "$ref": "../../common/beaconCommonComponents.json#/definitions/ApiVersion"
+            "$ref": "../../common/beaconCommonComponents.json#/$defs/ApiVersion"
         },
         "createDateTime": {
             "description": "The date/time the Beacon was created (ISO 8601 format).",
@@ -83,10 +83,10 @@
             "type": "string"
         },
         "id": {
-            "$ref": "../../common/beaconCommonComponents.json#/definitions/BeaconId"
+            "$ref": "../../common/beaconCommonComponents.json#/$defs/BeaconId"
         },
         "info": {
-            "$ref": "../../common/beaconCommonComponents.json#/definitions/Info",
+            "$ref": "../../common/beaconCommonComponents.json#/$defs/Info",
             "description": "Additional unspecified metadata about the Beacon service."
         },
         "name": {
@@ -94,7 +94,7 @@
             "type": "string"
         },
         "organization": {
-            "$ref": "#/definitions/BeaconOrganization"
+            "$ref": "#/$defs/BeaconOrganization"
         },
         "updateDateTime": {
             "description": "The time the Beacon was updated in (ISO 8601 format).",
@@ -105,7 +105,7 @@
             "type": "string"
         },
         "version": {
-            "$ref": "../../common/beaconCommonComponents.json#/definitions/ApiVersion",
+            "$ref": "../../common/beaconCommonComponents.json#/$defs/ApiVersion",
             "description": "TODO: This is a legacy use / duplication?"
         },
         "welcomeUrl": {

--- a/framework/json/responses/sections/beaconInformationalResponseMeta.json
+++ b/framework/json/responses/sections/beaconInformationalResponseMeta.json
@@ -5,13 +5,13 @@
     "description": "Meta information about the response.",
     "properties": {
         "apiVersion": {
-            "$ref": "../../common/beaconCommonComponents.json#/definitions/ApiVersion"
+            "$ref": "../../common/beaconCommonComponents.json#/$defs/ApiVersion"
         },
         "beaconId": {
-            "$ref": "../../common/beaconCommonComponents.json#/definitions/BeaconId"
+            "$ref": "../../common/beaconCommonComponents.json#/$defs/BeaconId"
         },
         "returnedSchemas": {
-            "$ref": "../../common/beaconCommonComponents.json#/definitions/ListOfSchemas"
+            "$ref": "../../common/beaconCommonComponents.json#/$defs/ListOfSchemas"
         }
     },
     "required": [

--- a/framework/json/responses/sections/beaconReceivedRequestSummary.json
+++ b/framework/json/responses/sections/beaconReceivedRequestSummary.json
@@ -3,18 +3,18 @@
     "description": "Section of the response that summarize the request received as it has been interpreted by the Beacon server. This summary can help to identify differences between the incoming request and its interpretation or processing, e.g. in the response granularity or pagination. The required properties include those that should be part of every request.",
     "properties": {
         "apiVersion": {
-            "$ref": "../../common/beaconCommonComponents.json#/definitions/ApiVersion",
+            "$ref": "../../common/beaconCommonComponents.json#/$defs/ApiVersion",
             "description": "API version expected by the client to be supported by the server and used in the response format."
         },
         "filters": {
-            "$ref": "../../common/beaconCommonComponents.json#/definitions/Filters",
+            "$ref": "../../common/beaconCommonComponents.json#/$defs/Filters",
             "description": "Filters as submitted in the request."
         },
         "includeResultsetResponses": {
-            "$ref": "../../common/beaconCommonComponents.json#/definitions/IncludeResultsetResponses"
+            "$ref": "../../common/beaconCommonComponents.json#/$defs/IncludeResultsetResponses"
         },
         "pagination": {
-            "$ref": "../../common/beaconCommonComponents.json#/definitions/Pagination",
+            "$ref": "../../common/beaconCommonComponents.json#/$defs/Pagination",
             "description": "Pagination as requested for the results."
         },
         "requestParameters": {
@@ -22,17 +22,17 @@
             "description": "Dictionary of request parameters received in the `RequestBody` or as part of a GET request."
         },
         "requestedGranularity": {
-            "$ref": "../../common/beaconCommonComponents.json#/definitions/Granularity",
+            "$ref": "../../common/beaconCommonComponents.json#/$defs/Granularity",
             "description": "Requested granularity for the response which may differe from the response's actual granularity."
         },
         "requestedSchemas": {
             "$comment": "TODO: Add the format attribute as a uri.",
-            "$ref": "../../common/beaconCommonComponents.json#/definitions/ListOfSchemas",
+            "$ref": "../../common/beaconCommonComponents.json#/$defs/ListOfSchemas",
             "description": "Set of schemas to be used in the response to a request. `minItems: 0` is used to confirm that an empty array is acceptable here.",
             "minItems": 0
         },
         "testMode": {
-            "$ref": "../../common/beaconCommonComponents.json#/definitions/TestMode",
+            "$ref": "../../common/beaconCommonComponents.json#/$defs/TestMode",
             "description": "Used for indicating that a request was received in a test context."
         }
     },

--- a/framework/json/responses/sections/beaconResponseMeta.json
+++ b/framework/json/responses/sections/beaconResponseMeta.json
@@ -3,24 +3,24 @@
     "description": "Information about the response that could be relevant for the Beacon client in order to interpret the results.",
     "properties": {
         "apiVersion": {
-            "$ref": "../../common/beaconCommonComponents.json#/definitions/ApiVersion"
+            "$ref": "../../common/beaconCommonComponents.json#/$defs/ApiVersion"
         },
         "beaconId": {
-            "$ref": "../../common/beaconCommonComponents.json#/definitions/BeaconId"
+            "$ref": "../../common/beaconCommonComponents.json#/$defs/BeaconId"
         },
         "receivedRequestSummary": {
             "$ref": "./beaconReceivedRequestSummary.json"
         },
         "returnedGranularity": {
-            "$ref": "../../common/beaconCommonComponents.json#/definitions/Granularity",
+            "$ref": "../../common/beaconCommonComponents.json#/$defs/Granularity",
             "description": "Granularity of the Beacon response which may differ from the requested one. For details see the prototype definition."
         },
         "returnedSchemas": {
-            "$ref": "../../common/beaconCommonComponents.json#/definitions/ListOfSchemas",
+            "$ref": "../../common/beaconCommonComponents.json#/$defs/ListOfSchemas",
             "description": "The `returnedSchemas` parameter indicates that the request has been interpreted for the indicated entity. This helps to disambiguate between negative responses due to e.g. no hit on a well understood request and failures to interpret or answer the request due to a missing entity. "
         },
         "testMode": {
-            "$ref": "../../common/beaconCommonComponents.json#/definitions/TestMode"
+            "$ref": "../../common/beaconCommonComponents.json#/$defs/TestMode"
         }
     },
     "required": [

--- a/framework/json/responses/sections/beaconResultsets.json
+++ b/framework/json/responses/sections/beaconResultsets.json
@@ -1,7 +1,5 @@
 {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "additionalProperties": true,
-    "definitions": {
+    "$defs": {
         "ResultsetInstance": {
             "additionalProperties": true,
             "properties": {
@@ -29,7 +27,7 @@
                     "type": "integer"
                 },
                 "resultsHandovers": {
-                    "$ref": "../../common/beaconCommonComponents.json#/definitions/ListOfHandovers",
+                    "$ref": "../../common/beaconCommonComponents.json#/$defs/ListOfHandovers",
                     "description": "List of handovers that apply to this resultset, not to the whole Beacon or to a result in particular."
                 },
                 "setType": {
@@ -48,14 +46,16 @@
             "type": "object"
         }
     },
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": true,
     "description": "Sets of results to be returned as query response.",
     "properties": {
         "$schema": {
-            "$ref": "../../common/beaconCommonComponents.json#/definitions/$schema"
+            "$ref": "../../common/beaconCommonComponents.json#/$defs/$schema"
         },
         "resultSets": {
             "items": {
-                "$ref": "#/definitions/ResultsetInstance"
+                "$ref": "#/$defs/ResultsetInstance"
             },
             "minItems": 0,
             "type": "array"

--- a/framework/json/responses/sections/beaconSummaryResponseSection.json
+++ b/framework/json/responses/sections/beaconSummaryResponseSection.json
@@ -3,10 +3,10 @@
     "description": "Beacon results summary section.",
     "properties": {
         "exists": {
-            "$ref": "../../common/beaconCommonComponents.json#/definitions/Exists"
+            "$ref": "../../common/beaconCommonComponents.json#/$defs/Exists"
         },
         "numTotalResults": {
-            "$ref": "../../common/beaconCommonComponents.json#/definitions/NumTotalResults"
+            "$ref": "../../common/beaconCommonComponents.json#/$defs/NumTotalResults"
         }
     },
     "required": [

--- a/framework/src/common/beaconCommonComponents.yaml
+++ b/framework/src/common/beaconCommonComponents.yaml
@@ -6,7 +6,7 @@ description: >-
   exclusively with one or the other.
   Separate schema documents are provided for complex components.
 type: object
-definitions:
+$defs:
   $schema:
     type: string
     $comment: 'TO REVIEW: adding a `format` or `regex` attribute that validates correctly
@@ -67,7 +67,7 @@ definitions:
       Set of schemas to be used in the response to a request.
     type: array
     items:
-      $ref: '#/definitions/SchemasPerEntity'
+      $ref: '#/$defs/SchemasPerEntity'
   SchemasPerEntity:
     description: >-
       Schema to be used for the requested entry type in the response.
@@ -91,24 +91,24 @@ definitions:
     type: object
     properties:
       skip:
-        $ref: '#/definitions/Skip'
+        $ref: '#/$defs/Skip'
       limit:
-        $ref: '#/definitions/Limit'
+        $ref: '#/$defs/Limit'
       currentPage:
         description: >-
           Token of the returned page. To be used only in the response to allow
           the client to check if the returned page is the one requested.
-        $ref: '#/definitions/PageToken'
+        $ref: '#/$defs/PageToken'
       nextPage:
         description: >-
           Token of the next page. Used to navigate forward. If empty, it is
           assumed that no more pages are available
-        $ref: '#/definitions/PageToken'
+        $ref: '#/$defs/PageToken'
       previousPage:
         description: >-
           Token of the previous page. Used to navigate backwards. If empty, it
           is assumed that the current page is the first one.
-        $ref: '#/definitions/PageToken'
+        $ref: '#/$defs/PageToken'
   Skip:
     description: >-
       * In the request: number of pages to skip
@@ -227,7 +227,7 @@ definitions:
     type: array
     items:
       description: Requested schema to be used for individuals in the response.
-      $ref: '#/definitions/Handover'
+      $ref: '#/$defs/Handover'
   Handover:
     type: object
     description: >-
@@ -247,7 +247,7 @@ definitions:
       - url
     properties:
       handoverType:
-        $ref: '#/definitions/HandoverType'
+        $ref: '#/$defs/HandoverType'
       note:
         type: string
         description: >-

--- a/framework/src/common/ontologyTerm.yaml
+++ b/framework/src/common/ontologyTerm.yaml
@@ -4,7 +4,7 @@ description: Definition of an ontology term.
 type: object
 properties:
   id:
-    $ref: './beaconCommonComponents.yaml#/definitions/CURIE'
+    $ref: './beaconCommonComponents.yaml#/$defs/CURIE'
   label:
     type: string
     description: The text that describes the term. By default it could be the preferred

--- a/framework/src/configuration/beaconConfigurationSchema.yaml
+++ b/framework/src/configuration/beaconConfigurationSchema.yaml
@@ -5,7 +5,7 @@ description: Files complaint with this schema are the configuration ones. The de
 type: object
 properties:
   $schema:
-    $ref: ../common/beaconCommonComponents.yaml#/definitions/$schema
+    $ref: ../common/beaconCommonComponents.yaml#/$defs/$schema
   maturityAttributes:
     description: Declares the level of maturity of the Beacon instance.
     type: object
@@ -31,7 +31,7 @@ properties:
       defaultGranularity:
         description: Default granularity. Some responses could return higher detail,
           but this would be the granularity by default.
-        $ref: ../common/beaconCommonComponents.yaml#/definitions/Granularity
+        $ref: ../common/beaconCommonComponents.yaml#/$defs/Granularity
       securityLevels:
         description: All access levels supported by the Beacon. Any combination is
           valid, as every option would apply to different parts of the Beacon.
@@ -44,8 +44,8 @@ properties:
           default:
             - CONTROLLED
   entryTypes:
-    $ref: '#/definitions/EntryTypes'
-definitions:
+    $ref: '#/$defs/EntryTypes'
+$defs:
   EntryTypes:
     description: This is a dictionary of the entry types implemented in this Beacon
       instance.

--- a/framework/src/configuration/beaconMapSchema.yaml
+++ b/framework/src/configuration/beaconMapSchema.yaml
@@ -5,7 +5,7 @@ description: Map of a Beacon, its entry types and endpoints. It isconceptually s
 type: object
 properties:
   $schema:
-    $ref: ../common/beaconCommonComponents.yaml#/definitions/$schema
+    $ref: ../common/beaconCommonComponents.yaml#/$defs/$schema
   endpointSets:
     description: List of enpoints included in this Beacon instance. This is list is
       meant to inform Beacon clients, e.g. a Beacon Network, about the available endpoints,
@@ -13,9 +13,9 @@ properties:
       validation purposes.
     type: object
     additionalProperties:
-      $ref: '#/definitions/Endpoint'
+      $ref: '#/$defs/Endpoint'
     minProperties: 1
-definitions:
+$defs:
   Endpoint:
     type: object
     properties:
@@ -63,7 +63,7 @@ definitions:
           OpenAPI definition referenced in the `openAPIEndpointsDefinition` attribute.
         type: object
         additionalProperties:
-          $ref: '#/definitions/RelatedEndpoint'
+          $ref: '#/$defs/RelatedEndpoint'
         minProperties: 0
     required:
       - entryType

--- a/framework/src/configuration/entryTypeDefinition.yaml
+++ b/framework/src/configuration/entryTypeDefinition.yaml
@@ -13,7 +13,7 @@ $comment: 'TO DO: The tagged parts should reference to `common/ontologizedElemen
   should not affect the resulting schema.'
 properties:
   $schema:
-    $ref: ../common/beaconCommonComponents.yaml#/definitions/$schema
+    $ref: ../common/beaconCommonComponents.yaml#/$defs/$schema
   id:
     $comments: ++++++ THIS IS THE START OF THE ontologized element ++++++
     type: string
@@ -62,7 +62,7 @@ properties:
     $comment: "TO DO: Double-check the proper way of referencing a path or relative\
       \ path. 'format: uri' is throwing validation errors for relative file paths"
   nonFilteredQueriesAllowed:
-    $ref: ../common/beaconCommonComponents.yaml#/definitions/NonFilteredQueriesAllowed
+    $ref: ../common/beaconCommonComponents.yaml#/$defs/NonFilteredQueriesAllowed
 required:
   - id
   - name

--- a/framework/src/configuration/entryTypesSchema.yaml
+++ b/framework/src/configuration/entryTypesSchema.yaml
@@ -5,8 +5,8 @@ type: object
 properties:
   entryTypes:
     description: List of entry types.
-    $ref: '#/definitions/EntryTypes'
-definitions:
+    $ref: '#/$defs/EntryTypes'
+$defs:
   EntryTypes:
     description: This is a dictionary of the entry types implemented in this Beacon
       instance.

--- a/framework/src/configuration/filteringTermsSchema.yaml
+++ b/framework/src/configuration/filteringTermsSchema.yaml
@@ -9,9 +9,9 @@ properties:
       in this instance of Beacon.
     type: array
     items:
-      $ref: '#/definitions/FilterTerm'
+      $ref: '#/$defs/FilterTerm'
     minItems: 0
-definitions:
+$defs:
   FilterTerm:
     type: object
     properties:

--- a/framework/src/endpoints.yaml
+++ b/framework/src/endpoints.yaml
@@ -143,9 +143,9 @@ components:
       name: skip
       in: query
       schema:
-        $ref: ./common/beaconCommonComponents.yaml#/definitions/Skip
+        $ref: ./common/beaconCommonComponents.yaml#/$defs/Skip
     limit:
       name: limit
       in: query
       schema:
-        $ref: ./common/beaconCommonComponents.yaml#/definitions/Limit
+        $ref: ./common/beaconCommonComponents.yaml#/$defs/Limit

--- a/framework/src/requests/beaconRequestBody.yaml
+++ b/framework/src/requests/beaconRequestBody.yaml
@@ -6,14 +6,14 @@ description: >-
 type: object
 properties:
   $schema:
-    $ref: ../common/beaconCommonComponents.yaml#/definitions/$schema
+    $ref: ../common/beaconCommonComponents.yaml#/$defs/$schema
   meta:
     description: >-
       Information relevant for building the response.
     $ref: ./beaconRequestMeta.yaml
   query:
-    $ref: '#/definitions/BeaconQuery'
-definitions:
+    $ref: '#/$defs/BeaconQuery'
+$defs:
   BeaconQuery:
     description: >-
       Parameters to limit the list of returned results.
@@ -28,23 +28,23 @@ definitions:
           Ontology based filters. Using CURIE syntax is encouraged.
         $ref: ./filteringTerms.yaml
       includeResultsetResponses:
-        $ref: ../common/beaconCommonComponents.yaml#/definitions/IncludeResultsetResponses
+        $ref: ../common/beaconCommonComponents.yaml#/$defs/IncludeResultsetResponses
       pagination:
         description: >-
           Pagination parameters applied to response documents, in case of record
           level granularity.
-        $ref: ../common/beaconCommonComponents.yaml#/definitions/Pagination
+        $ref: ../common/beaconCommonComponents.yaml#/$defs/Pagination
       requestedGranularity:
         description: >-
           Requested granularity for the response. Beacons do not have to respond
           with the requested granularity, e.g. may respond with count results
           although record level granularity had been requested but indicate the
           granularity of the response in the response's metadata.
-        $ref: ../common/beaconCommonComponents.yaml#/definitions/Granularity
+        $ref: ../common/beaconCommonComponents.yaml#/$defs/Granularity
       testMode:
         description: >-
           Used for indicating that a request or response is done in a test
           context.
-        $ref: ../common/beaconCommonComponents.yaml#/definitions/TestMode
+        $ref: ../common/beaconCommonComponents.yaml#/$defs/TestMode
 required:
   - meta

--- a/framework/src/requests/beaconRequestMeta.yaml
+++ b/framework/src/requests/beaconRequestMeta.yaml
@@ -4,13 +4,13 @@ description: Meta section of the Beacon request. It includes request context det
 type: object
 properties:
   $schema:
-    $ref: ../common/beaconCommonComponents.yaml#/definitions/$schema
+    $ref: ../common/beaconCommonComponents.yaml#/$defs/$schema
   apiVersion:
     description: API version expected by the client to be supported by the server
       and used in the response format.
-    $ref: ../common/beaconCommonComponents.yaml#/definitions/ApiVersion
+    $ref: ../common/beaconCommonComponents.yaml#/$defs/ApiVersion
   requestedSchemas:
     description: Set of schemas to be used in the response.
-    $ref: ../common/beaconCommonComponents.yaml#/definitions/ListOfSchemas
+    $ref: ../common/beaconCommonComponents.yaml#/$defs/ListOfSchemas
 required:
   - apiVersion

--- a/framework/src/requests/filteringTerms.yaml
+++ b/framework/src/requests/filteringTerms.yaml
@@ -8,13 +8,13 @@ description: >-
   to be chained by the logical AND operator.
 type: array
 items:
-  $ref: '#/definitions/FilteringTerm'
-definitions:
+  $ref: '#/$defs/FilteringTerm'
+$defs:
   FilteringTerm:
     anyOf:
-      - $ref: '#/definitions/OntologyFilter'
-      - $ref: '#/definitions/AlphanumericFilter'
-      - $ref: '#/definitions/CustomFilter'  
+      - $ref: '#/$defs/OntologyFilter'
+      - $ref: '#/$defs/AlphanumericFilter'
+      - $ref: '#/$defs/CustomFilter'  
   OntologyFilter:
     type: object
     description: Filter results to include records that contain a specific ontology

--- a/framework/src/responses/beaconBooleanResponse.yaml
+++ b/framework/src/responses/beaconBooleanResponse.yaml
@@ -17,13 +17,13 @@ properties:
     description: >-
       Additional details that could be of interest. Provided to clearly
       enclose any attribute that is not part of the Beacon specification.
-    $ref: ../common/beaconCommonComponents.yaml#/definitions/Info
+    $ref: ../common/beaconCommonComponents.yaml#/$defs/Info
   beaconHandovers:
     description: >-
       List of handovers that apply to the whole response, not to any resultset
       or result in particular.
 
-    $ref: ../common/beaconCommonComponents.yaml#/definitions/ListOfHandovers
+    $ref: ../common/beaconCommonComponents.yaml#/$defs/ListOfHandovers
 required:
   - meta
   - responseSummary

--- a/framework/src/responses/beaconCollectionsResponse.yaml
+++ b/framework/src/responses/beaconCollectionsResponse.yaml
@@ -27,11 +27,11 @@ properties:
     description: >-
       Additional details that could be of interest. Provided to clearly
       enclose any attribute that is not part of the Beacon specification.
-    $ref: ../common/beaconCommonComponents.yaml#/definitions/Info
+    $ref: ../common/beaconCommonComponents.yaml#/$defs/Info
   beaconHandovers:
     description: List of handovers that apply to the whole response, not to any resultset
       or result in particular.
-    $ref: ../common/beaconCommonComponents.yaml#/definitions/ListOfHandovers
+    $ref: ../common/beaconCommonComponents.yaml#/$defs/ListOfHandovers
 required:
   - meta
   - responseSummary

--- a/framework/src/responses/beaconCountResponse.yaml
+++ b/framework/src/responses/beaconCountResponse.yaml
@@ -17,12 +17,12 @@ properties:
     description: >-
       Additional details that could be of interest. Provided to clearly
       enclose any attribute that is not part of the Beacon specification.
-    $ref: ../common/beaconCommonComponents.yaml#/definitions/Info
+    $ref: ../common/beaconCommonComponents.yaml#/$defs/Info
   beaconHandovers:
     description: >-
       List of handovers that apply to the whole response, not to any resultset
       or result in particular.
-    $ref: ../common/beaconCommonComponents.yaml#/definitions/ListOfHandovers
+    $ref: ../common/beaconCommonComponents.yaml#/$defs/ListOfHandovers
 required:
   - meta
   - responseSummary

--- a/framework/src/responses/beaconErrorResponse.yaml
+++ b/framework/src/responses/beaconErrorResponse.yaml
@@ -6,7 +6,7 @@ properties:
   meta:
     $ref: ./sections/beaconResponseMeta.yaml
   error:
-    $ref: ../common/beaconCommonComponents.yaml#/definitions/BeaconError
+    $ref: ../common/beaconCommonComponents.yaml#/$defs/BeaconError
 required:
   - meta
   - error

--- a/framework/src/responses/beaconResultsetsResponse.yaml
+++ b/framework/src/responses/beaconResultsetsResponse.yaml
@@ -15,12 +15,12 @@ properties:
     description: >-
       Additional details that could be of interest. Provided to clearly
       enclose any attribute that is not part of the Beacon specification.
-    $ref: ../common/beaconCommonComponents.yaml#/definitions/Info
+    $ref: ../common/beaconCommonComponents.yaml#/$defs/Info
   beaconHandovers:
     description: >-
       List of handovers that apply to the whole response, not to any resultset
       or result in particular.
-    $ref: ../common/beaconCommonComponents.yaml#/definitions/ListOfHandovers
+    $ref: ../common/beaconCommonComponents.yaml#/$defs/ListOfHandovers
   response:
     description: >-
       Response for queries that recovers any result.

--- a/framework/src/responses/ga4gh-service-info-1-0-0-schema.yaml
+++ b/framework/src/responses/ga4gh-service-info-1-0-0-schema.yaml
@@ -25,7 +25,7 @@ properties:
       Name of this service. Should be human readable.
     example: My project
   type:
-    $ref: '#/definitions/ServiceType'
+    $ref: '#/$defs/ServiceType'
   description:
     type: string
     description: >-
@@ -91,7 +91,7 @@ properties:
       but other identifiers, such as dates or commit hashes, are also allowed. The
       version should be changed whenever the service is updated.
     example: 1.0.0
-definitions:
+$defs:
   ServiceType:
     description: Type of a GA4GH service
     type: object

--- a/framework/src/responses/sections/beaconBooleanResponseSection.yaml
+++ b/framework/src/responses/sections/beaconBooleanResponseSection.yaml
@@ -5,4 +5,4 @@ required:
   - exists
 properties:
   exists:
-    $ref: ../../common/beaconCommonComponents.yaml#/definitions/Exists
+    $ref: ../../common/beaconCommonComponents.yaml#/$defs/Exists

--- a/framework/src/responses/sections/beaconCountResponseSection.yaml
+++ b/framework/src/responses/sections/beaconCountResponseSection.yaml
@@ -4,10 +4,10 @@ description: >-
 type: object
 properties:
   exists:
-    $ref: ../../common/beaconCommonComponents.yaml#/definitions/Exists
+    $ref: ../../common/beaconCommonComponents.yaml#/$defs/Exists
   numTotalResults:
     description: Total number of results.
-    $ref: ../../common/beaconCommonComponents.yaml#/definitions/NumTotalResults
+    $ref: ../../common/beaconCommonComponents.yaml#/$defs/NumTotalResults
 required:
   - exists
   - numTotalResults

--- a/framework/src/responses/sections/beaconFilteringTermsResults.yaml
+++ b/framework/src/responses/sections/beaconFilteringTermsResults.yaml
@@ -6,12 +6,12 @@ properties:
   resources:
     type: array
     items:
-      $ref: '#/definitions/Resource'
+      $ref: '#/$defs/Resource'
   filteringTerms:
     type: array
     items:
-      $ref: '#/definitions/FilteringTerm'
-definitions:
+      $ref: '#/$defs/FilteringTerm'
+$defs:
   FilteringTerm:
     type: object
     description: >-

--- a/framework/src/responses/sections/beaconInfoResults.yaml
+++ b/framework/src/responses/sections/beaconInfoResults.yaml
@@ -10,13 +10,13 @@ required:
   - organization
 properties:
   id:
-    $ref: ../../common/beaconCommonComponents.yaml#/definitions/BeaconId
+    $ref: ../../common/beaconCommonComponents.yaml#/$defs/BeaconId
   name:
     type: string
     description: >-
       Name of the Beacon.
   apiVersion:
-    $ref: ../../common/beaconCommonComponents.yaml#/definitions/ApiVersion
+    $ref: ../../common/beaconCommonComponents.yaml#/$defs/ApiVersion
   environment:
     type: string
     description: "Environment the service is running in. Use this to distinguish\n\
@@ -29,7 +29,7 @@ properties:
     examples: 
       - dev
   organization:
-    $ref: '#/definitions/BeaconOrganization'
+    $ref: '#/$defs/BeaconOrganization'
   description:
     type: string
     description: >-
@@ -37,7 +37,7 @@ properties:
   version:
     description: >-
       TODO: This is a legacy use / duplication?
-    $ref: ../../common/beaconCommonComponents.yaml#/definitions/ApiVersion
+    $ref: ../../common/beaconCommonComponents.yaml#/$defs/ApiVersion
   welcomeUrl:
     type: string
     description: >-
@@ -67,8 +67,8 @@ properties:
   info:
     description: >-
       Additional unspecified metadata about the Beacon service.
-    $ref: ../../common/beaconCommonComponents.yaml#/definitions/Info
-definitions:
+    $ref: ../../common/beaconCommonComponents.yaml#/$defs/Info
+$defs:
   BeaconOrganization:
     description: >-
       Organization owning the Beacon.
@@ -109,5 +109,5 @@ definitions:
           3986 format).
       info:
         description: Additional unspecified metadata about the host Organization.
-        $ref: ../../common/beaconCommonComponents.yaml#/definitions/Info
+        $ref: ../../common/beaconCommonComponents.yaml#/$defs/Info
 additionalProperties: true

--- a/framework/src/responses/sections/beaconInformationalResponseMeta.yaml
+++ b/framework/src/responses/sections/beaconInformationalResponseMeta.yaml
@@ -4,11 +4,11 @@ description: >-
 type: object
 properties:
   beaconId:
-    $ref: ../../common/beaconCommonComponents.yaml#/definitions/BeaconId
+    $ref: ../../common/beaconCommonComponents.yaml#/$defs/BeaconId
   apiVersion:
-    $ref: ../../common/beaconCommonComponents.yaml#/definitions/ApiVersion
+    $ref: ../../common/beaconCommonComponents.yaml#/$defs/ApiVersion
   returnedSchemas:
-    $ref: ../../common/beaconCommonComponents.yaml#/definitions/ListOfSchemas
+    $ref: ../../common/beaconCommonComponents.yaml#/$defs/ListOfSchemas
 $comment: 'TO REVIEW: the required properties below results in a warning in the example.'
 required:
   - beaconId

--- a/framework/src/responses/sections/beaconReceivedRequestSummary.yaml
+++ b/framework/src/responses/sections/beaconReceivedRequestSummary.yaml
@@ -11,39 +11,39 @@ properties:
     description: >-
       API version expected by the client to be supported by the server
       and used in the response format.
-    $ref: ../../common/beaconCommonComponents.yaml#/definitions/ApiVersion
+    $ref: ../../common/beaconCommonComponents.yaml#/$defs/ApiVersion
   requestedSchemas:
     description: >-
       Set of schemas to be used in the response to a request.
       `minItems: 0` is used to confirm that an empty array is acceptable here.
-    $ref: ../../common/beaconCommonComponents.yaml#/definitions/ListOfSchemas
+    $ref: ../../common/beaconCommonComponents.yaml#/$defs/ListOfSchemas
     minItems: 0
     $comment: >-
       TODO: Add the format attribute as a uri.
   filters:
     description: >-
       Filters as submitted in the request.
-    $ref: ../../common/beaconCommonComponents.yaml#/definitions/Filters
+    $ref: ../../common/beaconCommonComponents.yaml#/$defs/Filters
   requestParameters:
     description: >-
       Dictionary of request parameters received in the `RequestBody` or as part
       of a GET request.
     $ref: ../../requests/requestParameters.yaml
   includeResultsetResponses:
-    $ref: ../../common/beaconCommonComponents.yaml#/definitions/IncludeResultsetResponses
+    $ref: ../../common/beaconCommonComponents.yaml#/$defs/IncludeResultsetResponses
   pagination:
     description: >-
       Pagination as requested for the results.
-    $ref: ../../common/beaconCommonComponents.yaml#/definitions/Pagination
+    $ref: ../../common/beaconCommonComponents.yaml#/$defs/Pagination
   requestedGranularity:
     description: >-
       Requested granularity for the response which may differe from the
       response's actual granularity.
-    $ref: ../../common/beaconCommonComponents.yaml#/definitions/Granularity
+    $ref: ../../common/beaconCommonComponents.yaml#/$defs/Granularity
   testMode:
     description: >-
       Used for indicating that a request was received in a test context.
-    $ref: ../../common/beaconCommonComponents.yaml#/definitions/TestMode
+    $ref: ../../common/beaconCommonComponents.yaml#/$defs/TestMode
 required:
   - apiVersion
   - requestedSchemas

--- a/framework/src/responses/sections/beaconResponseMeta.yaml
+++ b/framework/src/responses/sections/beaconResponseMeta.yaml
@@ -5,23 +5,23 @@ description: >-
 type: object
 properties:
   beaconId:
-    $ref: ../../common/beaconCommonComponents.yaml#/definitions/BeaconId
+    $ref: ../../common/beaconCommonComponents.yaml#/$defs/BeaconId
   apiVersion:
-    $ref: ../../common/beaconCommonComponents.yaml#/definitions/ApiVersion
+    $ref: ../../common/beaconCommonComponents.yaml#/$defs/ApiVersion
   returnedSchemas:
     description: >-
       The `returnedSchemas` parameter indicates that the request has been interpreted
       for the indicated entity. This helps to disambiguate between negative responses
       due to e.g. no hit on a well understood request and failures to interpret or
       answer the request due to a missing entity. 
-    $ref: ../../common/beaconCommonComponents.yaml#/definitions/ListOfSchemas
+    $ref: ../../common/beaconCommonComponents.yaml#/$defs/ListOfSchemas
   returnedGranularity:
     description: >-
       Granularity of the Beacon response which may differ from the requested one.
       For details see the prototype definition.
-    $ref: ../../common/beaconCommonComponents.yaml#/definitions/Granularity
+    $ref: ../../common/beaconCommonComponents.yaml#/$defs/Granularity
   testMode:
-    $ref: ../../common/beaconCommonComponents.yaml#/definitions/TestMode
+    $ref: ../../common/beaconCommonComponents.yaml#/$defs/TestMode
   receivedRequestSummary:
     $ref: ./beaconReceivedRequestSummary.yaml
 required:

--- a/framework/src/responses/sections/beaconResultsets.yaml
+++ b/framework/src/responses/sections/beaconResultsets.yaml
@@ -4,16 +4,16 @@ description: Sets of results to be returned as query response.
 type: object
 properties:
   $schema:
-    $ref: ../../common/beaconCommonComponents.yaml#/definitions/$schema
+    $ref: ../../common/beaconCommonComponents.yaml#/$defs/$schema
   resultSets:
     type: array
     items:
-      $ref: '#/definitions/ResultsetInstance'
+      $ref: '#/$defs/ResultsetInstance'
     minItems: 0
 required:
   - resultSets
 additionalProperties: true
-definitions:
+$defs:
   ResultsetInstance:
     type: object
     properties:
@@ -34,7 +34,7 @@ definitions:
       resultsHandovers:
         description: List of handovers that apply to this resultset, not to the whole
           Beacon or to a result in particular.
-        $ref: ../../common/beaconCommonComponents.yaml#/definitions/ListOfHandovers
+        $ref: ../../common/beaconCommonComponents.yaml#/$defs/ListOfHandovers
       info:
         description: Additional details that could be of interest about the Resultset.
           Provided to clearly enclose any attribute that is not part of the Beacon

--- a/framework/src/responses/sections/beaconSummaryResponseSection.yaml
+++ b/framework/src/responses/sections/beaconSummaryResponseSection.yaml
@@ -3,8 +3,8 @@ description: Beacon results summary section.
 type: object
 properties:
   exists:
-    $ref: ../../common/beaconCommonComponents.yaml#/definitions/Exists
+    $ref: ../../common/beaconCommonComponents.yaml#/$defs/Exists
   numTotalResults:
-    $ref: ../../common/beaconCommonComponents.yaml#/definitions/NumTotalResults
+    $ref: ../../common/beaconCommonComponents.yaml#/$defs/NumTotalResults
 required:
   - exists

--- a/models/json/beacon-v2-default-model/analyses/defaultSchema.json
+++ b/models/json/beacon-v2-default-model/analyses/defaultSchema.json
@@ -38,7 +38,7 @@
             "type": "string"
         },
         "info": {
-            "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/Info"
+            "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Info"
         },
         "pipelineName": {
             "description": "Analysis pipeline and version if a standardized pipeline was used",

--- a/models/json/beacon-v2-default-model/analyses/endpoints.json
+++ b/models/json/beacon-v2-default-model/analyses/endpoints.json
@@ -25,13 +25,13 @@
                 }
             },
             "includeResultsetResponses": {
-                "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/IncludeResultsetResponses"
+                "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/IncludeResultsetResponses"
             },
             "limit": {
                 "in": "query",
                 "name": "limit",
                 "schema": {
-                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/Limit"
+                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Limit"
                 }
             },
             "requestedSchema": {
@@ -48,7 +48,7 @@
                 "in": "query",
                 "name": "skip",
                 "schema": {
-                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/Skip"
+                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Skip"
                 }
             }
         },

--- a/models/json/beacon-v2-default-model/biosamples/defaultSchema.json
+++ b/models/json/beacon-v2-default-model/biosamples/defaultSchema.json
@@ -82,7 +82,7 @@
             "type": "string"
         },
         "info": {
-            "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/Info"
+            "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Info"
         },
         "measurements": {
             "description": "List of measurements of the sample.",

--- a/models/json/beacon-v2-default-model/biosamples/endpoints.json
+++ b/models/json/beacon-v2-default-model/biosamples/endpoints.json
@@ -29,13 +29,13 @@
                 }
             },
             "includeResultsetResponses": {
-                "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/IncludeResultsetResponses"
+                "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/IncludeResultsetResponses"
             },
             "limit": {
                 "in": "query",
                 "name": "limit",
                 "schema": {
-                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/Limit"
+                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Limit"
                 }
             },
             "requestedSchema": {
@@ -52,7 +52,7 @@
                 "in": "query",
                 "name": "skip",
                 "schema": {
-                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/Skip"
+                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Skip"
                 }
             }
         },

--- a/models/json/beacon-v2-default-model/cohorts/defaultSchema.json
+++ b/models/json/beacon-v2-default-model/cohorts/defaultSchema.json
@@ -1,8 +1,6 @@
 {
     "$comment": "version: ga4gh-beacon-cohort-v2.0.0",
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "additionalProperties": true,
-    "definitions": {
+    "$defs": {
         "CohortCriteria": {
             "description": "Criteria used for defining the cohort. It is assumed that all cohort participants will match or NOT match such criteria.",
             "properties": {
@@ -20,21 +18,21 @@
                 "ethnicities": {
                     "description": "Ethnias in cohort inclusion criteria",
                     "items": {
-                        "$ref": "../common/commonDefinitions.json#/definitions/Ethnicity"
+                        "$ref": "../common/commonDefinitions.json#/$defs/Ethnicity"
                     },
                     "type": "array"
                 },
                 "genders": {
                     "description": "Gender(s) in cohort inclusion criteria",
                     "items": {
-                        "$ref": "../common/commonDefinitions.json#/definitions/Sex"
+                        "$ref": "../common/commonDefinitions.json#/$defs/Sex"
                     },
                     "type": "array"
                 },
                 "locations": {
                     "description": "Geographic location(s) in cohort inclusion criteria",
                     "items": {
-                        "$ref": "../common/commonDefinitions.json#/definitions/GeographicLocation"
+                        "$ref": "../common/commonDefinitions.json#/$defs/GeographicLocation"
                     },
                     "type": "array"
                 },
@@ -52,7 +50,7 @@
             "description": "TBD",
             "properties": {
                 "eventAgeRange": {
-                    "$ref": "#/definitions/DataAvailabilityAndDistribution",
+                    "$ref": "#/$defs/DataAvailabilityAndDistribution",
                     "description": "Individual age range, obtained from individual level info of the cohort members"
                 },
                 "eventCases": {
@@ -72,7 +70,7 @@
                     "type": "integer"
                 },
                 "eventDataTypes": {
-                    "$ref": "#/definitions/DataAvailabilityAndDistribution",
+                    "$ref": "#/$defs/DataAvailabilityAndDistribution",
                     "description": "Aggregated data type information available for each cohort data type as declared in `cohortDataTypes`, and obtained from individual level info of the cohort members",
                     "type": "object"
                 },
@@ -87,19 +85,19 @@
                     "type": "string"
                 },
                 "eventDiseases": {
-                    "$ref": "#/definitions/DataAvailabilityAndDistribution",
+                    "$ref": "#/$defs/DataAvailabilityAndDistribution",
                     "description": "Aggregated information of disease/condition(s) obtained from individual level info of the cohort members"
                 },
                 "eventEthnicities": {
-                    "$ref": "#/definitions/DataAvailabilityAndDistribution",
+                    "$ref": "#/$defs/DataAvailabilityAndDistribution",
                     "description": "Aggregated information of ethnicity obtained from individual level info of the cohort members"
                 },
                 "eventGenders": {
-                    "$ref": "#/definitions/DataAvailabilityAndDistribution",
+                    "$ref": "#/$defs/DataAvailabilityAndDistribution",
                     "description": "Aggregated information of gender(s) obtained from individual level info of the cohort members"
                 },
                 "eventLocations": {
-                    "$ref": "#/definitions/DataAvailabilityAndDistribution",
+                    "$ref": "#/$defs/DataAvailabilityAndDistribution",
                     "description": "Aggregated information of geographic location obtained from individual level info of the cohort members"
                 },
                 "eventNum": {
@@ -113,7 +111,7 @@
                     "type": "integer"
                 },
                 "eventPhenotypes": {
-                    "$ref": "#/definitions/DataAvailabilityAndDistribution",
+                    "$ref": "#/$defs/DataAvailabilityAndDistribution",
                     "description": "Aggregated information of phenotype(s) obtained from individual level info of the cohort members"
                 },
                 "eventSize": {
@@ -208,10 +206,12 @@
             "type": "array"
         }
     },
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": true,
     "description": "A cohort available in the beacon.",
     "properties": {
         "cohortDataTypes": {
-            "$ref": "#/definitions/DataTypesArray"
+            "$ref": "#/$defs/DataTypesArray"
         },
         "cohortDesign": {
             "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/ontologyTerm.json",
@@ -252,12 +252,12 @@
         "collectionEvents": {
             "description": "TBD",
             "items": {
-                "$ref": "#/definitions/CollectionEvent"
+                "$ref": "#/$defs/CollectionEvent"
             },
             "type": "array"
         },
         "exclusionCriteria": {
-            "$ref": "#/definitions/CohortCriteria",
+            "$ref": "#/$defs/CohortCriteria",
             "description": "Exclusion criteria used for defining the cohort. It is assumed that NONE of the cohort participants will match such criteria.",
             "type": "object"
         },
@@ -269,7 +269,7 @@
             "type": "string"
         },
         "inclusionCriteria": {
-            "$ref": "#/definitions/CohortCriteria",
+            "$ref": "#/$defs/CohortCriteria",
             "description": "Inclusion criteria used for defining the cohort. It is assumed that all cohort participants will match such criteria.",
             "type": "object"
         },

--- a/models/json/beacon-v2-default-model/cohorts/endpoints.json
+++ b/models/json/beacon-v2-default-model/cohorts/endpoints.json
@@ -28,7 +28,7 @@
                 "in": "query",
                 "name": "limit",
                 "schema": {
-                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/Limit"
+                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Limit"
                 }
             },
             "requestedSchema": {
@@ -45,7 +45,7 @@
                 "in": "query",
                 "name": "skip",
                 "schema": {
-                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/Skip"
+                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Skip"
                 }
             }
         },

--- a/models/json/beacon-v2-default-model/common/age.json
+++ b/models/json/beacon-v2-default-model/common/age.json
@@ -3,7 +3,7 @@
     "description": "Age value definition. Provenance: GA4GH Phenopackets v2 `Age`",
     "properties": {
         "iso8601duration": {
-            "description": "Represents age as a ISO8601 duration (e.g., 'P40Y10M05D').",
+            "description": "Represents age as a ISO8601 duration (e.g., P40Y10M05D).",
             "example": "P32Y6M1D",
             "type": "string"
         }

--- a/models/json/beacon-v2-default-model/common/ageRange.json
+++ b/models/json/beacon-v2-default-model/common/ageRange.json
@@ -12,8 +12,8 @@
         }
     },
     "required": [
-        "end",
-        "start"
+        "start",
+        "end"
     ],
     "title": "AgeRange",
     "type": "object"

--- a/models/json/beacon-v2-default-model/common/commonDefinitions.json
+++ b/models/json/beacon-v2-default-model/common/commonDefinitions.json
@@ -1,6 +1,5 @@
 {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "definitions": {
+    "$defs": {
         "Ethnicity": {
             "$ref": "../../../../framework/json/common/ontologyTerm.json",
             "description": "Ethnic background of the individual. Recommended is the use of a value from NCIT Race (NCIT:C17049) ontology term descendants, e.g. NCIT:C126531 (Latin American). A geographic ancestral origin category that is assigned to a population group based mainly on physical characteristics that are thought to be distinct and inherent. [ NCI ]",
@@ -148,6 +147,7 @@
             ]
         }
     },
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "description": "Definitions for concepts used in several entry types, but that having only one property are not complex enough to require a full independent schema document.",
     "title": "Common Definitions"
 }

--- a/models/json/beacon-v2-default-model/common/complexValue.json
+++ b/models/json/beacon-v2-default-model/common/complexValue.json
@@ -1,6 +1,5 @@
 {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "definitions": {
+    "$defs": {
         "TypedQuantity": {
             "properties": {
                 "quantity": {
@@ -30,17 +29,20 @@
             ]
         }
     },
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "description": "Definition of a complex value class. Provenance: GA4GH Phenopackets v2 `TypedQuantity`",
     "properties": {
         "typedQuantities": {
             "description": "List of quantities required to fully describe the complex value",
             "items": {
-                "$ref": "#/definitions/TypedQuantity"
+                "$ref": "#/$defs/TypedQuantity"
             },
             "type": "array"
         }
     },
-    "required": [ "typedQuantities" ],
+    "required": [
+        "typedQuantities"
+    ],
     "title": "Complex Value",
     "type": "object"
 }

--- a/models/json/beacon-v2-default-model/common/dataUseConditions.json
+++ b/models/json/beacon-v2-default-model/common/dataUseConditions.json
@@ -1,7 +1,5 @@
 {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "additionalProperties": true,
-    "definitions": {
+    "$defs": {
         "DUODataUse": {
             "allOf": [
                 {
@@ -60,11 +58,13 @@
             ]
         }
     },
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": true,
     "description": "Data use conditions",
     "properties": {
         "duoDataUse": {
             "items": {
-                "$ref": "#/definitions/DUODataUse"
+                "$ref": "#/$defs/DUODataUse"
             },
             "minItems": 1,
             "type": "array"

--- a/models/json/beacon-v2-default-model/common/disease.json
+++ b/models/json/beacon-v2-default-model/common/disease.json
@@ -58,7 +58,7 @@
             "type": "string"
         },
         "severity": {
-            "$ref": "./commonDefinitions.json#/definitions/SeverityLevel",
+            "$ref": "./commonDefinitions.json#/$defs/SeverityLevel",
             "examples": [
                 {
                     "id": "HP:0012828",

--- a/models/json/beacon-v2-default-model/common/exposure.json
+++ b/models/json/beacon-v2-default-model/common/exposure.json
@@ -33,7 +33,7 @@
             ]
         },
         "unit": {
-            "$ref": "../common/commonDefinitions.json#/definitions/Unit",
+            "$ref": "../common/commonDefinitions.json#/$defs/Unit",
             "description": "Unit of the exposure. Recommended from NCIT Unit of Category ontology term (NCIT:C42568) descendants."
         },
         "value": {

--- a/models/json/beacon-v2-default-model/common/pedigree.json
+++ b/models/json/beacon-v2-default-model/common/pedigree.json
@@ -1,7 +1,5 @@
 {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "additionalProperties": true,
-    "definitions": {
+    "$defs": {
         "pedigreeMember": {
             "examples": [
                 {
@@ -97,6 +95,8 @@
             "type": "object"
         }
     },
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": true,
     "description": "Pedigree studies in which the individual is part of.",
     "properties": {
         "disease": {
@@ -110,7 +110,7 @@
         "members": {
             "description": "List of members of the pedigree. If the current pedigree definition is attached to the proband, it contains the whole list of pedigree members, including the proband. If the definition is attached to an individual different than the proband, it only contains two entries: one that describes that member, e.g. the proband mother or father, and one that points to the proband.",
             "items": {
-                "$ref": "#/definitions/pedigreeMember"
+                "$ref": "#/$defs/pedigreeMember"
             },
             "minItems": 1,
             "type": "array"

--- a/models/json/beacon-v2-default-model/common/phenotypicFeature.json
+++ b/models/json/beacon-v2-default-model/common/phenotypicFeature.json
@@ -1,6 +1,6 @@
 {
+    "$defs": {},
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "definitions": {},
     "description": "Used to describe a phenotype that characterizes the subject or biosample.",
     "properties": {
         "evidence": {
@@ -61,7 +61,7 @@
             "description": "Age or time at which the feature resolved or abated."
         },
         "severity": {
-            "$ref": "./commonDefinitions.json#/definitions/SeverityLevel",
+            "$ref": "./commonDefinitions.json#/$defs/SeverityLevel",
             "examples": [
                 {
                     "id": "HP:0012828",

--- a/models/json/beacon-v2-default-model/common/quantity.json
+++ b/models/json/beacon-v2-default-model/common/quantity.json
@@ -9,7 +9,7 @@
             "example": {}
         },
         "unit": {
-            "$ref": "./commonDefinitions.json#/definitions/Unit"
+            "$ref": "./commonDefinitions.json#/$defs/Unit"
         },
         "value": {
             "description": "The value of the quantity in the units",

--- a/models/json/beacon-v2-default-model/common/referenceRange.json
+++ b/models/json/beacon-v2-default-model/common/referenceRange.json
@@ -18,7 +18,7 @@
             "type": "number"
         },
         "unit": {
-            "$ref": "./commonDefinitions.json#/definitions/Unit",
+            "$ref": "./commonDefinitions.json#/$defs/Unit",
             "description": "The kind of unit.",
             "examples": [
                 {

--- a/models/json/beacon-v2-default-model/common/timeElement.json
+++ b/models/json/beacon-v2-default-model/common/timeElement.json
@@ -13,7 +13,7 @@
             "$ref": "./gestationalAge.json"
         },
         {
-            "$ref": "./commonDefinitions.json#/definitions/Timestamp"
+            "$ref": "./commonDefinitions.json#/$defs/Timestamp"
         },
         {
             "$ref": "./timeInterval.json"

--- a/models/json/beacon-v2-default-model/common/timeInterval.json
+++ b/models/json/beacon-v2-default-model/common/timeInterval.json
@@ -5,13 +5,13 @@
     "description": "Time interval with start and end defined as ISO8601 time stamps.",
     "properties": {
         "end": {
-            "$ref": "./commonDefinitions.json#/definitions/Timestamp",
+            "$ref": "./commonDefinitions.json#/$defs/Timestamp",
             "examples": [
                 "2022-03-10T15:25:07Z"
             ]
         },
         "start": {
-            "$ref": "./commonDefinitions.json#/definitions/Timestamp",
+            "$ref": "./commonDefinitions.json#/$defs/Timestamp",
             "examples": [
                 "1999-08-05T17:21:00+01:00",
                 "2002-09-21T02:37:00-08:00"

--- a/models/json/beacon-v2-default-model/datasets/defaultSchema.json
+++ b/models/json/beacon-v2-default-model/datasets/defaultSchema.json
@@ -5,7 +5,7 @@
     "description": "A dataset available in the beacon",
     "properties": {
         "createDateTime": {
-            "$ref": "../common/commonDefinitions.json#/definitions/Timestamp",
+            "$ref": "../common/commonDefinitions.json#/$defs/Timestamp",
             "description": "The time the dataset was created (ISO 8601 format)",
             "examples": [
                 "2017-01-17T20:33:40Z"
@@ -37,7 +37,7 @@
             "type": "string"
         },
         "info": {
-            "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/Info"
+            "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Info"
         },
         "name": {
             "description": "Name of the dataset",
@@ -47,7 +47,7 @@
             "type": "string"
         },
         "updateDateTime": {
-            "$ref": "../common/commonDefinitions.json#/definitions/Timestamp",
+            "$ref": "../common/commonDefinitions.json#/$defs/Timestamp",
             "description": "The time the dataset was updated in (ISO 8601 format)",
             "examples": [
                 "2017-01-17T20:33:40Z"

--- a/models/json/beacon-v2-default-model/datasets/endpoints.json
+++ b/models/json/beacon-v2-default-model/datasets/endpoints.json
@@ -26,7 +26,7 @@
                 "in": "query",
                 "name": "limit",
                 "schema": {
-                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/Limit"
+                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Limit"
                 }
             },
             "requestedSchema": {
@@ -43,7 +43,7 @@
                 "in": "query",
                 "name": "skip",
                 "schema": {
-                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/Skip"
+                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Skip"
                 }
             }
         },

--- a/models/json/beacon-v2-default-model/endpoints.json
+++ b/models/json/beacon-v2-default-model/endpoints.json
@@ -5,7 +5,7 @@
                 "in": "query",
                 "name": "limit",
                 "schema": {
-                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/Limit"
+                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Limit"
                 }
             },
             "requestedSchema": {
@@ -22,7 +22,7 @@
                 "in": "query",
                 "name": "skip",
                 "schema": {
-                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/Skip"
+                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Skip"
                 }
             }
         },

--- a/models/json/beacon-v2-default-model/genomicVariations/defaultSchema.json
+++ b/models/json/beacon-v2-default-model/genomicVariations/defaultSchema.json
@@ -1,8 +1,6 @@
 {
     "$comment": "version: ga4gh-beacon-variant-v2.0.0",
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "additionalProperties": true,
-    "definitions": {
+    "$defs": {
         "CaseLevelVariant": {
             "description": "",
             "properties": {
@@ -56,7 +54,7 @@
                 },
                 "clinicalInterpretations": {
                     "items": {
-                        "$ref": "#/definitions/PhenoClinicEffect"
+                        "$ref": "#/$defs/PhenoClinicEffect"
                     },
                     "type": "array"
                 },
@@ -76,7 +74,7 @@
                 },
                 "phenotypicEffects": {
                     "items": {
-                        "$ref": "#/definitions/PhenoClinicEffect"
+                        "$ref": "#/$defs/PhenoClinicEffect"
                     },
                     "type": "array"
                 },
@@ -115,7 +113,7 @@
             "properties": {
                 "frequencies": {
                     "items": {
-                        "$ref": "#/definitions/PopulationFrequency"
+                        "$ref": "#/$defs/PopulationFrequency"
                     },
                     "minItems": 1,
                     "type": "array"
@@ -340,7 +338,7 @@
                 "genomicFeatures": {
                     "description": "List of Genomic feature(s) affected by the variant.",
                     "items": {
-                        "$ref": "#/definitions/GenomicFeature"
+                        "$ref": "#/$defs/GenomicFeature"
                     },
                     "type": "array"
                 },
@@ -368,7 +366,7 @@
             "description": "List of annotated effects on disease or phenotypes.",
             "properties": {
                 "annotatedWith": {
-                    "$ref": "#/definitions/SoftwareTool"
+                    "$ref": "#/$defs/SoftwareTool"
                 },
                 "category": {
                     "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/ontologyTerm.json",
@@ -508,13 +506,13 @@
             "properties": {
                 "clinicalInterpretations": {
                     "items": {
-                        "$ref": "#/definitions/PhenoClinicEffect"
+                        "$ref": "#/$defs/PhenoClinicEffect"
                     },
                     "type": "array"
                 },
                 "phenotypicEffects": {
                     "items": {
-                        "$ref": "#/definitions/PhenoClinicEffect"
+                        "$ref": "#/$defs/PhenoClinicEffect"
                     },
                     "type": "array"
                 }
@@ -522,26 +520,28 @@
             "type": "object"
         }
     },
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": true,
     "description": "Schema for a genomic variant entry.",
     "properties": {
         "caseLevelData": {
             "description": "caseLevelData reports about the variation instances observed in individual analyses.",
             "items": {
-                "$ref": "#/definitions/CaseLevelVariant"
+                "$ref": "#/$defs/CaseLevelVariant"
             },
             "type": "array"
         },
         "frequencyInPopulations": {
             "items": {
-                "$ref": "#/definitions/FrequencyInPopulations"
+                "$ref": "#/$defs/FrequencyInPopulations"
             },
             "type": "array"
         },
         "identifiers": {
-            "$ref": "#/definitions/Identifiers"
+            "$ref": "#/$defs/Identifiers"
         },
         "molecularAttributes": {
-            "$ref": "#/definitions/MolecularAttributes"
+            "$ref": "#/$defs/MolecularAttributes"
         },
         "variantInternalId": {
             "description": "Reference to the **internal** variant ID. This represents the primary key/identifier of that variant **inside** a given Beacon instance. Different Beacon instances may use identical id values, referring to unrelated variants. Public identifiers such as the GA4GH Variant Representation Id (VRSid) MUST be returned in the `identifiers` section. A Beacon instance can, of course, use the VRSid as their own internal id but still MUST represent this then in the `identifiers` section.",
@@ -552,7 +552,7 @@
             "type": "string"
         },
         "variantLevelData": {
-            "$ref": "#/definitions/VariantLevelData"
+            "$ref": "#/$defs/VariantLevelData"
         },
         "variation": {
             "oneOf": [
@@ -563,7 +563,7 @@
                     "$ref": "https://raw.githubusercontent.com/ga4gh/vrs/1.2/schema/vrs.json#/definitions/SystemicVariation"
                 },
                 {
-                    "$ref": "#/definitions/LegacyVariation"
+                    "$ref": "#/$defs/LegacyVariation"
                 }
             ]
         }

--- a/models/json/beacon-v2-default-model/genomicVariations/endpoints.json
+++ b/models/json/beacon-v2-default-model/genomicVariations/endpoints.json
@@ -81,13 +81,13 @@
                 }
             },
             "includeResultsetResponses": {
-                "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/IncludeResultsetResponses"
+                "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/IncludeResultsetResponses"
             },
             "limit": {
                 "in": "query",
                 "name": "limit",
                 "schema": {
-                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/Limit"
+                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Limit"
                 }
             },
             "referenceBases": {
@@ -118,7 +118,7 @@
                 "in": "query",
                 "name": "skip",
                 "schema": {
-                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/Skip"
+                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Skip"
                 }
             },
             "start": {

--- a/models/json/beacon-v2-default-model/genomicVariations/requestParameters.json
+++ b/models/json/beacon-v2-default-model/genomicVariations/requestParameters.json
@@ -3,7 +3,7 @@
     "g_variant": {
         "properties": {
             "alternateBases": {
-                "$ref": "./requestParametersComponents.json#/definitions/AlternateBases"
+                "$ref": "./requestParametersComponents.json#/$defs/AlternateBases"
             },
             "aminoacidChange": {
                 "description": "Aminoacid alteration of interest. Format 1 letter",
@@ -14,10 +14,10 @@
                 "type": "string"
             },
             "assemblyId": {
-                "$ref": "./requestParametersComponents.json#/definitions/Assembly"
+                "$ref": "./requestParametersComponents.json#/$defs/Assembly"
             },
             "end": {
-                "description": "Precise or bracketing the end of the variants of interest: * (0-based, exclusive) - see `start` * for bracket queries, provide 2 values (e.g. [111,222]).",
+                "description": "Precise or bracketing the end of the variants of interest: * (0-based, exclusive) - see `start` * for bracket queries, provide 2 values (e.g. [111,222]).\"",
                 "items": {
                     "format": "int64",
                     "minimum": 1,
@@ -43,16 +43,16 @@
                 "type": "string"
             },
             "mateName": {
-                "$ref": "./requestParametersComponents.json#/definitions/RefSeqId"
+                "$ref": "./requestParametersComponents.json#/$defs/RefSeqId"
             },
             "referenceBases": {
-                "$ref": "./requestParametersComponents.json#/definitions/ReferenceBases"
+                "$ref": "./requestParametersComponents.json#/$defs/ReferenceBases"
             },
             "referenceName": {
-                "$ref": "./requestParametersComponents.json#/definitions/RefSeqId"
+                "$ref": "./requestParametersComponents.json#/$defs/RefSeqId"
             },
             "start": {
-                "description": "Precise or fuzzy start coordinate position(s), allele locus (0-based, inclusive). * `start` only:\n  - for single positions, e.g. the start of a specified sequence\nalteration where the size is given through the specified `alternateBases`\n  - typical use are queries for SNV and small InDels\n  - the use of `start` without an `end` parameter requires the use of\n`alternateBases`\n* 1 value each in both `start` and `end`:\n  - for searching any variant falling fully or partially within the range\n    between `start` and `end` (a.k.a. \"range query\")\n  - additional use of `variantType` OR `alternateBases` can limit the\n    scope of the query\n  - by convention, partial overlaps of variants with the indicated genomic\n    range are accepted; for specific overlap requirements the 4-parameter\n    \"Bracket Queries\" should be employed\n* 2 values in both `start` and `end` for constructing a \"Bracket Query\":\n  - can be used to match any contiguous genomic interval, e.g. for querying\n    imprecise positions\n  - identifies all structural variants starting between `start[0]` and `start[1]`,\n    and ending between `end[0]` <-> `end[1]`\n  - single or double sided precise matches can be achieved by setting\n    `start[1]=start[0]+1` and `end[1]=end[0]+1`",
+                "description": "Precise or fuzzy start coordinate position(s), allele locus (0-based, inclusive). * `start` only:\n  - for single positions, e.g. the start of a specified sequence\n    alteration where the size is given through the specified `alternateBases`\n  - typical use are queries for SNV and small InDels\n  - the use of `start` without an `end` parameter requires the use of\n    `alternateBases`\n* 1 value in both `start` and `end`:\n  - for searching any variant falling fully or partially within the range\n    between `start` and `end` (a.k.a. \"range query\")\n  - additional use of `variantType` OR `alternateBases` can limit the\n    scope of the query\n  - by convention, partial overlaps of variants with the indicated genomic\n    range are accepted; for specific overlap requirements the 4-parameter\n    \"Bracket Queries\" should be employed\n* 2 values in both `start` and `end` for constructing a \"Bracket Query\":\n  - can be used to match any contiguous genomic interval, e.g. for querying\n    imprecise positions\n  - identifies all structural variants starting between `start[0]` and `start[1]`,\n    and ending between `end[0]` <-> `end[1]`\n  - single or double sided precise matches can be achieved by setting\n    `start[1]=start[0]+1` and `end[1]=end[0]+1`",
                 "items": {
                     "format": "int64",
                     "minimum": 0,

--- a/models/json/beacon-v2-default-model/genomicVariations/requestParametersComponents.json
+++ b/models/json/beacon-v2-default-model/genomicVariations/requestParametersComponents.json
@@ -1,6 +1,5 @@
 {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "definitions": {
+    "$defs": {
         "AlternateBases": {
             "description": "Alternate bases for this variant (starting from `start`). * Accepted values: `[ACGTN]*` * The current specification supports allelic variants, **not** genotype queries\n  (i.e. multiple co-occurring alleles).\n* N is a wildcard, that denotes the position of any base,\n  and can be used as a standalone base of any type or within a partially known\n  sequence. As example, a query of `ANNT` the Ns can take take any form of [ACGT]\n  and will match `ANNT`, `ACNT`, `ACCT`, `ACGT` ... and so forth.\n* an *empty value* is used in the case of deletions with the maximally trimmed,\n  deleted sequence being indicated in `ReferenceBases`\n* Categorical variant queries, e.g. such *not* being represented through\n  sequence & position, make use of the `variantType` parameter.",
             "pattern": "^([ACGTUNRYSWKMBDHV\\-\\.]*)$",
@@ -30,5 +29,6 @@
             "type": "string"
         }
     },
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "description": "Component definitions used in `requestParameters`."
 }

--- a/models/json/beacon-v2-default-model/individuals/defaultSchema.json
+++ b/models/json/beacon-v2-default-model/individuals/defaultSchema.json
@@ -12,7 +12,7 @@
             "type": "array"
         },
         "ethnicity": {
-            "$ref": "../common/commonDefinitions.json#/definitions/Ethnicity",
+            "$ref": "../common/commonDefinitions.json#/$defs/Ethnicity",
             "description": "Ethnic background of the individual. Value from NCIT Race (NCIT:C17049) ontology term descendants, e.g. NCIT:C126531 (Latin American). A geographic ancestral origin category that is assigned to a population group based mainly on physical characteristics that are thought to be distinct and inherent. [ NCI ] "
         },
         "exposures": {
@@ -22,7 +22,7 @@
             "type": "array"
         },
         "geographicOrigin": {
-            "$ref": "../common/commonDefinitions.json#/definitions/GeographicLocation",
+            "$ref": "../common/commonDefinitions.json#/$defs/GeographicLocation",
             "description": "Individual's country or region of origin (birthplace or residence place regardless of ethnic origin). Value from GAZ Geographic Location ontology (GAZ:00000448), e.g. GAZ:00002459 (United States of America)."
         },
         "id": {
@@ -31,7 +31,7 @@
             "type": "string"
         },
         "info": {
-            "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/Info"
+            "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Info"
         },
         "interventionsOrProcedures": {
             "items": {
@@ -40,7 +40,7 @@
             "type": "array"
         },
         "karyotypicSex": {
-            "$ref": "../common/commonDefinitions.json#/definitions/KaryotypicSex",
+            "$ref": "../common/commonDefinitions.json#/$defs/KaryotypicSex",
             "description": "The chromosomal sex of an individual represented from a selection of options."
         },
         "measures": {
@@ -62,7 +62,7 @@
             "type": "array"
         },
         "sex": {
-            "$ref": "../common/commonDefinitions.json#/definitions/Sex",
+            "$ref": "../common/commonDefinitions.json#/$defs/Sex",
             "description": "Sex of the individual. Value from NCIT General Qualifier (NCIT:C27993): 'unknown' (not assessed or not available) (NCIT:C17998), 'female' (NCIT:C16576), or 'male', (NCIT:C20197)."
         },
         "treatments": {

--- a/models/json/beacon-v2-default-model/individuals/endpoints.json
+++ b/models/json/beacon-v2-default-model/individuals/endpoints.json
@@ -25,13 +25,13 @@
                 }
             },
             "includeResultsetResponses": {
-                "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/IncludeResultsetResponses"
+                "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/IncludeResultsetResponses"
             },
             "limit": {
                 "in": "query",
                 "name": "limit",
                 "schema": {
-                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/Limit"
+                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Limit"
                 }
             },
             "requestedSchema": {
@@ -48,7 +48,7 @@
                 "in": "query",
                 "name": "skip",
                 "schema": {
-                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/Skip"
+                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Skip"
                 }
             }
         },

--- a/models/json/beacon-v2-default-model/runs/defaultSchema.json
+++ b/models/json/beacon-v2-default-model/runs/defaultSchema.json
@@ -26,7 +26,7 @@
             "type": "string"
         },
         "info": {
-            "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/Info"
+            "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Info"
         },
         "libraryLayout": {
             "description": "Ontology value for the library layout e.g \"PAIRED\", \"SINGLE\" #todo add Ontology name?",

--- a/models/json/beacon-v2-default-model/runs/endpoints.json
+++ b/models/json/beacon-v2-default-model/runs/endpoints.json
@@ -33,7 +33,7 @@
                 }
             },
             "includeResultsetResponses": {
-                "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/IncludeResultsetResponses"
+                "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/IncludeResultsetResponses"
             },
             "individualId": {
                 "in": "path",
@@ -47,7 +47,7 @@
                 "in": "query",
                 "name": "limit",
                 "schema": {
-                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/Limit"
+                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Limit"
                 }
             },
             "requestedSchema": {
@@ -64,7 +64,7 @@
                 "in": "query",
                 "name": "skip",
                 "schema": {
-                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/Skip"
+                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Skip"
                 }
             }
         },

--- a/models/src/beacon-v2-default-model/analyses/defaultSchema.yaml
+++ b/models/src/beacon-v2-default-model/analyses/defaultSchema.yaml
@@ -51,7 +51,7 @@ properties:
     examples:
       - GATK4.0
   info:
-    $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/Info
+    $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Info
 required:
   - id
   - analysisDate

--- a/models/src/beacon-v2-default-model/analyses/endpoints.yaml
+++ b/models/src/beacon-v2-default-model/analyses/endpoints.yaml
@@ -143,14 +143,14 @@ components:
       name: skip
       in: query
       schema:
-        $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/Skip
+        $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Skip
     limit:
       name: limit
       in: query
       schema:
-        $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/Limit
+        $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Limit
     includeResultsetResponses:
-      $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/IncludeResultsetResponses
+      $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/IncludeResultsetResponses
     entryId:
       name: id
       in: path

--- a/models/src/beacon-v2-default-model/biosamples/defaultSchema.yaml
+++ b/models/src/beacon-v2-default-model/biosamples/defaultSchema.yaml
@@ -160,7 +160,7 @@ properties:
     $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/ontologyTerm.json
     example: {}
   info:
-    $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/Info
+    $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Info
 required:
   - id
   - biosampleStatus

--- a/models/src/beacon-v2-default-model/biosamples/endpoints.yaml
+++ b/models/src/beacon-v2-default-model/biosamples/endpoints.yaml
@@ -219,14 +219,14 @@ components:
       name: skip
       in: query
       schema:
-        $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/Skip
+        $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Skip
     limit:
       name: limit
       in: query
       schema:
-        $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/Limit
+        $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Limit
     includeResultsetResponses:
-      $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/IncludeResultsetResponses
+      $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/IncludeResultsetResponses
     entryId:
       name: id
       in: path

--- a/models/src/beacon-v2-default-model/cohorts/defaultSchema.yaml
+++ b/models/src/beacon-v2-default-model/cohorts/defaultSchema.yaml
@@ -52,13 +52,13 @@ properties:
       Inclusion criteria used for defining the cohort. It is assumed that
       all cohort participants will match such criteria.
     type: object
-    $ref: '#/definitions/CohortCriteria'
+    $ref: '#/$defs/CohortCriteria'
   exclusionCriteria:
     description: >-
       Exclusion criteria used for defining the cohort. It is assumed that
       NONE of the cohort participants will match such criteria.
     type: object
-    $ref: '#/definitions/CohortCriteria'
+    $ref: '#/$defs/CohortCriteria'
   cohortSize:
     description: >-
       Count of unique Individuals in cohort (individuals meeting criteria
@@ -69,13 +69,13 @@ properties:
       - 14765
       - 20000
   cohortDataTypes:
-    $ref: '#/definitions/DataTypesArray'
+    $ref: '#/$defs/DataTypesArray'
   collectionEvents:
     description: TBD
     type: array
     items:
-      $ref: '#/definitions/CollectionEvent'
-definitions:
+      $ref: '#/$defs/CollectionEvent'
+$defs:
   CollectionEvent:
     description: TBD
     type: object
@@ -145,39 +145,39 @@ definitions:
         description: >-
           Aggregated information of geographic location obtained from individual
           level info of the cohort members
-        $ref: '#/definitions/DataAvailabilityAndDistribution'
+        $ref: '#/$defs/DataAvailabilityAndDistribution'
       eventGenders:
         description: >-
           Aggregated information of gender(s) obtained from individual
           level info of the cohort members
-        $ref: '#/definitions/DataAvailabilityAndDistribution'
+        $ref: '#/$defs/DataAvailabilityAndDistribution'
       eventEthnicities:
         description: >-
           Aggregated information of ethnicity obtained from individual
           level info of the cohort members
-        $ref: '#/definitions/DataAvailabilityAndDistribution'
+        $ref: '#/$defs/DataAvailabilityAndDistribution'
       eventAgeRange:
         description: >-
           Individual age range, obtained from individual level info of the
           cohort members
-        $ref: '#/definitions/DataAvailabilityAndDistribution'
+        $ref: '#/$defs/DataAvailabilityAndDistribution'
       eventDiseases:
         description: >-
           Aggregated information of disease/condition(s) obtained from
           individual level info of the cohort members
-        $ref: '#/definitions/DataAvailabilityAndDistribution'
+        $ref: '#/$defs/DataAvailabilityAndDistribution'
       eventPhenotypes:
         description: >-
           Aggregated information of phenotype(s) obtained from individual
           level info of the cohort members
-        $ref: '#/definitions/DataAvailabilityAndDistribution'
+        $ref: '#/$defs/DataAvailabilityAndDistribution'
       eventDataTypes:
         description: >-
           Aggregated data type information available for each cohort data
           type as declared in `cohortDataTypes`, and obtained from individual
           level info of the cohort members
         type: object
-        $ref: '#/definitions/DataAvailabilityAndDistribution'
+        $ref: '#/$defs/DataAvailabilityAndDistribution'
   CohortCriteria:
     description: >-
       Criteria used for defining the cohort. It is assumed that all cohort
@@ -189,19 +189,19 @@ definitions:
           Geographic location(s) in cohort inclusion criteria
         type: array
         items:
-          $ref: ../common/commonDefinitions.yaml#/definitions/GeographicLocation
+          $ref: ../common/commonDefinitions.yaml#/$defs/GeographicLocation
       genders:
         description: >-
           Gender(s) in cohort inclusion criteria
         type: array
         items:
-          $ref: ../common/commonDefinitions.yaml#/definitions/Sex
+          $ref: ../common/commonDefinitions.yaml#/$defs/Sex
       ethnicities:
         description: >-
           Ethnias in cohort inclusion criteria
         type: array
         items:
-          $ref: ../common/commonDefinitions.yaml#/definitions/Ethnicity
+          $ref: ../common/commonDefinitions.yaml#/$defs/Ethnicity
       diseaseConditions:
         description: >-
           Diseases in cohort inclusion criteria

--- a/models/src/beacon-v2-default-model/cohorts/endpoints.yaml
+++ b/models/src/beacon-v2-default-model/cohorts/endpoints.yaml
@@ -196,12 +196,12 @@ components:
       name: skip
       in: query
       schema:
-        $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/Skip
+        $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Skip
     limit:
       name: limit
       in: query
       schema:
-        $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/Limit
+        $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Limit
     entryId:
       name: id
       in: path

--- a/models/src/beacon-v2-default-model/common/commonDefinitions.yaml
+++ b/models/src/beacon-v2-default-model/common/commonDefinitions.yaml
@@ -2,7 +2,7 @@ $schema: https://json-schema.org/draft/2020-12/schema
 title: Common Definitions
 description: Definitions for concepts used in several entry types, but that having
   only one property are not complex enough to require a full independent schema document.
-definitions:
+$defs:
   Sex:
     description: 'Sex of the individual. Recommended values from NCIT General Qualifier
       (NCIT:C27993): "unknown" (not assessed or not available) - NCIT:C17998; "female"

--- a/models/src/beacon-v2-default-model/common/complexValue.yaml
+++ b/models/src/beacon-v2-default-model/common/complexValue.yaml
@@ -8,11 +8,11 @@ properties:
     description: List of quantities required to fully describe the complex value
     type: array
     items:
-      $ref: '#/definitions/TypedQuantity'
+      $ref: '#/$defs/TypedQuantity'
 required:
   - typedQuantities
 
-definitions:
+$defs:
   TypedQuantity:
     properties:
       quantityType:

--- a/models/src/beacon-v2-default-model/common/dataUseConditions.yaml
+++ b/models/src/beacon-v2-default-model/common/dataUseConditions.yaml
@@ -6,9 +6,9 @@ properties:
   duoDataUse:
     type: array
     items:
-      $ref: '#/definitions/DUODataUse'
+      $ref: '#/$defs/DUODataUse'
     minItems: 1
-definitions:
+$defs:
   DUODataUse:
     allOf:
       - description: Data Use Ontology codes and additional information associated

--- a/models/src/beacon-v2-default-model/common/disease.yaml
+++ b/models/src/beacon-v2-default-model/common/disease.yaml
@@ -40,7 +40,7 @@ properties:
       - id: OGMS:0000106
         label: remission
   severity:
-    $ref: ./commonDefinitions.yaml#/definitions/SeverityLevel
+    $ref: ./commonDefinitions.yaml#/$defs/SeverityLevel
     examples:
       - id: HP:0012828
         label: Severe

--- a/models/src/beacon-v2-default-model/common/exposure.yaml
+++ b/models/src/beacon-v2-default-model/common/exposure.yaml
@@ -22,7 +22,7 @@ properties:
     description: >-
       Unit of the exposure. Recommended from NCIT Unit of Category ontology
       term (NCIT:C42568) descendants.
-    $ref: ../common/commonDefinitions.yaml#/definitions/Unit
+    $ref: ../common/commonDefinitions.yaml#/$defs/Unit
   duration:
     description: >-
       Exposure duration in ISO8601 format

--- a/models/src/beacon-v2-default-model/common/pedigree.yaml
+++ b/models/src/beacon-v2-default-model/common/pedigree.yaml
@@ -21,9 +21,9 @@ properties:
       than the proband, it only contains two entries: one that describes that member,
       e.g. the proband mother or father, and one that points to the proband.'
     items:
-      $ref: '#/definitions/pedigreeMember'
+      $ref: '#/$defs/pedigreeMember'
     minItems: 1
-definitions:
+$defs:
   pedigreeMember:
     type: object
     properties:

--- a/models/src/beacon-v2-default-model/common/phenotypicFeature.yaml
+++ b/models/src/beacon-v2-default-model/common/phenotypicFeature.yaml
@@ -50,7 +50,7 @@ properties:
     description: The evidence for an assertion of the observation of a type. RECOMMENDED.
     $ref: ./evidence.yaml
   severity:
-    $ref: ./commonDefinitions.yaml#/definitions/SeverityLevel
+    $ref: ./commonDefinitions.yaml#/$defs/SeverityLevel
     examples:
       - id: HP:0012828
         label: Severe
@@ -61,6 +61,6 @@ properties:
       feature.
     type: string
     example: Some free text
-definitions: {}
+$defs: {}
 required:
   - featureType

--- a/models/src/beacon-v2-default-model/common/quantity.yaml
+++ b/models/src/beacon-v2-default-model/common/quantity.yaml
@@ -4,7 +4,7 @@ description: 'Definition of a quantity class. Provenance: GA4GH Phenopackets v2 
 type: object
 properties:
   unit:
-    $ref: ./commonDefinitions.yaml#/definitions/Unit
+    $ref: ./commonDefinitions.yaml#/$defs/Unit
   value:
     description: The value of the quantity in the units
     type: number

--- a/models/src/beacon-v2-default-model/common/referenceRange.yaml
+++ b/models/src/beacon-v2-default-model/common/referenceRange.yaml
@@ -5,7 +5,7 @@ type: object
 properties:
   unit:
     description: The kind of unit.
-    $ref: ./commonDefinitions.yaml#/definitions/Unit
+    $ref: ./commonDefinitions.yaml#/$defs/Unit
     examples:
       - id: NCIT:C49670
         label: Millimeter of Mercury

--- a/models/src/beacon-v2-default-model/common/timeElement.yaml
+++ b/models/src/beacon-v2-default-model/common/timeElement.yaml
@@ -9,6 +9,6 @@ oneOf:
   - $ref: ./age.yaml
   - $ref: ./ageRange.yaml
   - $ref: ./gestationalAge.yaml
-  - $ref: ./commonDefinitions.yaml#/definitions/Timestamp
+  - $ref: ./commonDefinitions.yaml#/$defs/Timestamp
   - $ref: ./timeInterval.yaml
   - $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/ontologyTerm.json

--- a/models/src/beacon-v2-default-model/common/timeInterval.yaml
+++ b/models/src/beacon-v2-default-model/common/timeInterval.yaml
@@ -5,12 +5,12 @@ type: object
 $comments: From https://github.com/phenopackets/phenopacket-schema/blob/v2/docs/time-interval.rst
 properties:
   start:
-    $ref: ./commonDefinitions.yaml#/definitions/Timestamp
+    $ref: ./commonDefinitions.yaml#/$defs/Timestamp
     examples:
       - '1999-08-05T17:21:00+01:00'
       - '2002-09-21T02:37:00-08:00'
   end:
-    $ref: ./commonDefinitions.yaml#/definitions/Timestamp
+    $ref: ./commonDefinitions.yaml#/$defs/Timestamp
     examples:
       - '2022-03-10T15:25:07Z'
 required:

--- a/models/src/beacon-v2-default-model/datasets/defaultSchema.yaml
+++ b/models/src/beacon-v2-default-model/datasets/defaultSchema.yaml
@@ -19,12 +19,12 @@ properties:
     examples:
       - This dataset provides examples of the actual data in this Beacon instance.
   createDateTime:
-    $ref: ../common/commonDefinitions.yaml#/definitions/Timestamp
+    $ref: ../common/commonDefinitions.yaml#/$defs/Timestamp
     description: The time the dataset was created (ISO 8601 format)
     examples:
       - '2017-01-17T20:33:40Z'
   updateDateTime:
-    $ref: ../common/commonDefinitions.yaml#/definitions/Timestamp
+    $ref: ../common/commonDefinitions.yaml#/$defs/Timestamp
     description: The time the dataset was updated in (ISO 8601 format)
     examples:
       - '2017-01-17T20:33:40Z'
@@ -40,7 +40,7 @@ properties:
     examples:
       - https://example.org/wiki/Main_Page
   info:
-    $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/Info
+    $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Info
   dataUseConditions:
     description: Data use conditions applying to this dataset.
     $ref: ../common/dataUseConditions.yaml

--- a/models/src/beacon-v2-default-model/datasets/endpoints.yaml
+++ b/models/src/beacon-v2-default-model/datasets/endpoints.yaml
@@ -270,12 +270,12 @@ components:
       name: skip
       in: query
       schema:
-        $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/Skip
+        $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Skip
     limit:
       name: limit
       in: query
       schema:
-        $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/Limit
+        $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Limit
     entryId:
       name: id
       in: path

--- a/models/src/beacon-v2-default-model/endpoints.yaml
+++ b/models/src/beacon-v2-default-model/endpoints.yaml
@@ -143,9 +143,9 @@ components:
       name: skip
       in: query
       schema:
-        $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/Skip
+        $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Skip
     limit:
       name: limit
       in: query
       schema:
-        $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/Limit
+        $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Limit

--- a/models/src/beacon-v2-default-model/genomicVariations/defaultSchema.yaml
+++ b/models/src/beacon-v2-default-model/genomicVariations/defaultSchema.yaml
@@ -12,7 +12,7 @@ properties:
     oneOf:
       - $ref: https://raw.githubusercontent.com/ga4gh/vrs/1.2/schema/vrs.json#/definitions/MolecularVariation
       - $ref: https://raw.githubusercontent.com/ga4gh/vrs/1.2/schema/vrs.json#/definitions/SystemicVariation
-      - $ref: '#/definitions/LegacyVariation'
+      - $ref: '#/$defs/LegacyVariation'
   variantInternalId:
     description: >-
       Reference to the **internal** variant ID. This represents the primary
@@ -27,22 +27,22 @@ properties:
       - var00001
       - v110112
   identifiers:
-    $ref: '#/definitions/Identifiers'
+    $ref: '#/$defs/Identifiers'
   molecularAttributes:
-    $ref: '#/definitions/MolecularAttributes'
+    $ref: '#/$defs/MolecularAttributes'
   caseLevelData:
     type: array
     description: caseLevelData reports about the variation instances observed in individual
       analyses.
     items:
-      $ref: '#/definitions/CaseLevelVariant'
+      $ref: '#/$defs/CaseLevelVariant'
   variantLevelData:
-    $ref: '#/definitions/VariantLevelData'
+    $ref: '#/$defs/VariantLevelData'
   frequencyInPopulations:
     type: array
     items:
-      $ref: '#/definitions/FrequencyInPopulations'
-definitions:
+      $ref: '#/$defs/FrequencyInPopulations'
+$defs:
   LegacyVariation:
     type: object
     required:
@@ -168,7 +168,7 @@ definitions:
         description: List of Genomic feature(s) affected by the variant.
         type: array
         items:
-          $ref: '#/definitions/GenomicFeature'
+          $ref: '#/$defs/GenomicFeature'
       molecularEffects:
         description: >-
           Ontology term that includes describes the class of molecular
@@ -270,7 +270,7 @@ definitions:
           - id: ECO:0000006
             label: experimental evidence
       annotatedWith:
-        $ref: '#/definitions/SoftwareTool'
+        $ref: '#/$defs/SoftwareTool'
     required:
       - conditionId
       - effect
@@ -297,7 +297,7 @@ definitions:
       frequencies:
         type: array
         items:
-          $ref: '#/definitions/PopulationFrequency'
+          $ref: '#/$defs/PopulationFrequency'
         minItems: 1
     required:
       - source
@@ -394,11 +394,11 @@ definitions:
       clinicalInterpretations:
         type: array
         items:
-          $ref: '#/definitions/PhenoClinicEffect'
+          $ref: '#/$defs/PhenoClinicEffect'
       phenotypicEffects:
         type: array
         items:
-          $ref: '#/definitions/PhenoClinicEffect'
+          $ref: '#/$defs/PhenoClinicEffect'
     required:
       - biosampleId
   VariantLevelData:
@@ -407,11 +407,11 @@ definitions:
       clinicalInterpretations:
         type: array
         items:
-          $ref: '#/definitions/PhenoClinicEffect'
+          $ref: '#/$defs/PhenoClinicEffect'
       phenotypicEffects:
         type: array
         items:
-          $ref: '#/definitions/PhenoClinicEffect'
+          $ref: '#/$defs/PhenoClinicEffect'
   SoftwareTool:
     type: object
     properties:

--- a/models/src/beacon-v2-default-model/genomicVariations/endpoints.yaml
+++ b/models/src/beacon-v2-default-model/genomicVariations/endpoints.yaml
@@ -187,14 +187,14 @@ components:
       name: skip
       in: query
       schema:
-        $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/Skip
+        $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Skip
     limit:
       name: limit
       in: query
       schema:
-        $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/Limit
+        $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Limit
     includeResultsetResponses:
-      $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/IncludeResultsetResponses
+      $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/IncludeResultsetResponses
     entryId:
       name: id
       in: path

--- a/models/src/beacon-v2-default-model/genomicVariations/requestParameters.yaml
+++ b/models/src/beacon-v2-default-model/genomicVariations/requestParameters.yaml
@@ -3,9 +3,9 @@ g_variant:
   type: object
   properties:
     assemblyId:
-      $ref: ./requestParametersComponents.yaml#/definitions/Assembly
+      $ref: ./requestParametersComponents.yaml#/$defs/Assembly
     referenceName:
-      $ref: ./requestParametersComponents.yaml#/definitions/RefSeqId
+      $ref: ./requestParametersComponents.yaml#/$defs/RefSeqId
     start:
       description: >-
         Precise or fuzzy start coordinate position(s), allele locus
@@ -51,9 +51,9 @@ g_variant:
       minItems: 1
       maxItems: 2
     referenceBases:
-      $ref: ./requestParametersComponents.yaml#/definitions/ReferenceBases
+      $ref: ./requestParametersComponents.yaml#/$defs/ReferenceBases
     alternateBases:
-      $ref: ./requestParametersComponents.yaml#/definitions/AlternateBases
+      $ref: ./requestParametersComponents.yaml#/$defs/AlternateBases
     variantType:
       description: >-
         The `variantType` is used to query variants which are not defined through
@@ -98,7 +98,7 @@ g_variant:
       format: int64
       minimum: 1
     mateName:
-      $ref: ./requestParametersComponents.yaml#/definitions/RefSeqId
+      $ref: ./requestParametersComponents.yaml#/$defs/RefSeqId
     geneId:
       description: >-
         * A gene identifier

--- a/models/src/beacon-v2-default-model/genomicVariations/requestParametersComponents.yaml
+++ b/models/src/beacon-v2-default-model/genomicVariations/requestParametersComponents.yaml
@@ -1,7 +1,7 @@
 $schema: https://json-schema.org/draft/2020-12/schema
 description: >-
   Component definitions used in `requestParameters`.
-definitions:
+$defs:
   Assembly:
     description: >-
       Genomic assembly accession and version as RefSqeq assembly accession

--- a/models/src/beacon-v2-default-model/individuals/defaultSchema.yaml
+++ b/models/src/beacon-v2-default-model/individuals/defaultSchema.yaml
@@ -12,23 +12,23 @@ properties:
     description: "Sex of the individual. Value from NCIT General Qualifier (NCIT:C27993):\
       \ 'unknown' (not assessed or not available) (NCIT:C17998), 'female' (NCIT:C16576),\
       \ or 'male', (NCIT:C20197)."
-    $ref: ../common/commonDefinitions.yaml#/definitions/Sex
+    $ref: ../common/commonDefinitions.yaml#/$defs/Sex
   karyotypicSex:
     description: The chromosomal sex of an individual represented from a selection
       of options.
-    $ref: ../common/commonDefinitions.yaml#/definitions/KaryotypicSex
+    $ref: ../common/commonDefinitions.yaml#/$defs/KaryotypicSex
   ethnicity:
     description: 'Ethnic background of the individual. Value from NCIT Race (NCIT:C17049)
       ontology term descendants, e.g. NCIT:C126531 (Latin American). A geographic
       ancestral origin category that is assigned to a population group based mainly
       on physical characteristics that are thought to be distinct and inherent. [
       NCI ] '
-    $ref: ../common/commonDefinitions.yaml#/definitions/Ethnicity
+    $ref: ../common/commonDefinitions.yaml#/$defs/Ethnicity
   geographicOrigin:
     description: Individual's country or region of origin (birthplace or residence
       place regardless of ethnic origin). Value from GAZ Geographic Location ontology
       (GAZ:00000448), e.g. GAZ:00002459 (United States of America).
-    $ref: ../common/commonDefinitions.yaml#/definitions/GeographicLocation
+    $ref: ../common/commonDefinitions.yaml#/$defs/GeographicLocation
   diseases:
     description: List of disease(s) been diagnosed to the individual, defined by disease
       ontology ID(s), age of onset, stage and the presence of family history.
@@ -60,7 +60,7 @@ properties:
     items:
       $ref: ../common/exposure.yaml
   info:
-    $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/Info
+    $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Info
 required:
   - id
   - sex

--- a/models/src/beacon-v2-default-model/individuals/endpoints.yaml
+++ b/models/src/beacon-v2-default-model/individuals/endpoints.yaml
@@ -214,14 +214,14 @@ components:
       name: skip
       in: query
       schema:
-        $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/Skip
+        $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Skip
     limit:
       name: limit
       in: query
       schema:
-        $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/Limit
+        $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Limit
     includeResultsetResponses:
-      $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/IncludeResultsetResponses
+      $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/IncludeResultsetResponses
     entryId:
       name: id
       in: path

--- a/models/src/beacon-v2-default-model/runs/defaultSchema.yaml
+++ b/models/src/beacon-v2-default-model/runs/defaultSchema.yaml
@@ -74,7 +74,7 @@ properties:
       - id: EFO:0010938
         label: large-insert clone DNA microarray
   info:
-    $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/Info
+    $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Info
 required:
   - id
   - biosampleId

--- a/models/src/beacon-v2-default-model/runs/endpoints.yaml
+++ b/models/src/beacon-v2-default-model/runs/endpoints.yaml
@@ -175,14 +175,14 @@ components:
       name: skip
       in: query
       schema:
-        $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/Skip
+        $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Skip
     limit:
       name: limit
       in: query
       schema:
-        $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/Limit
+        $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Limit
     includeResultsetResponses:
-      $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/IncludeResultsetResponses
+      $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/IncludeResultsetResponses
     entryId:
       name: id
       in: path


### PR DESCRIPTION
This aligns the use of the "definitions" parameter to the "$defs" keyword as required from https://json-schema.org/draft/2020-12/schema as pointed out by @jrambla in https://github.com/ga4gh-beacon/beacon-v2/issues/153

Editing of the YAML files with conversion... Additional changes include a change in the beaconYamler.py utility (use of system Python instead of fixed path) and a few updates of json files due to previous manual editing and now re-arranged parameter order after autoconversion from yaml.



