### PR TITLE
VRS references fix

### DIFF
--- a/bin/beacon_yaml2md.pl
+++ b/bin/beacon_yaml2md.pl
@@ -729,9 +729,9 @@ sub add_properties_vrs {
     my ( $property, $data ) = @_;
     my %url = (
         'SequenceExpression' =>
-'https://raw.githubusercontent.com/ga4gh/vrs/1.2/schema/vrs.json#/definitions/',
+'https://w3id.org/ga4gh/schema/vrs/1.2/vrs.json#/definitions/',
         'CopyNumber' =>
-'https://raw.githubusercontent.com/ga4gh/vrs/1.2/schema/vrs.json#/definitions/'
+'https://w3id.org/ga4gh/schema/vrs/1.2/vrs.json#/definitions/'
     );
     if ( exists $url{$property} ) {
         $data->{properties} =

--- a/bin/deref_schemas/obj/CopyNumber.yaml
+++ b/bin/deref_schemas/obj/CopyNumber.yaml
@@ -1,4 +1,4 @@
 ---
 CopyNumber:
-  properties: '[VRS definition for CopyNumber](https://raw.githubusercontent.com/ga4gh/vrs/1.2/schema/vrs.json#/definitions/CopyNumber)'
+  properties: '[VRS definition for CopyNumber](https://w3id.org/ga4gh/schema/vrs/1.2/vrs.json#/definitions/CopyNumber)'
   type: allOf

--- a/docs/schemas-md/obj/CopyNumber.md
+++ b/docs/schemas-md/obj/CopyNumber.md
@@ -1,3 +1,3 @@
 |Term | Description | Type | Properties | Example | Enum|
 | ---| ---| ---| ---| ---| --- |
-| CopyNumber | NA | allOf | [VRS definition for CopyNumber](https://raw.githubusercontent.com/ga4gh/vrs/1.2/schema/vrs.json#/definitions/CopyNumber) | NA | NA|
+| CopyNumber | NA | allOf | [VRS definition for CopyNumber](https://w3id.org/ga4gh/schema/vrs/1.2/vrs.json#/definitions/CopyNumber) | NA | NA|

--- a/models/json/beacon-v2-default-model/genomicVariations/defaultSchema.json
+++ b/models/json/beacon-v2-default-model/genomicVariations/defaultSchema.json
@@ -272,7 +272,7 @@
                     "type": "string"
                 },
                 "location": {
-                    "$ref": "https://raw.githubusercontent.com/ga4gh/vrs/main/schema/vrs.json#/definitions/Location"
+                    "$ref": "https://w3id.org/ga4gh/schema/vrs/1.2/vrs.json#/definitions/Location"
                 },
                 "referenceBases": {
                     "description": "Reference bases for this variant (starting from `start`). * Accepted values: IUPAC codes for nucleotides (e.g. `https://www.bioinformatics.org/sms/iupac.html`). * N is a wildcard, that denotes the position of any base, and can be used\n  as a standalone base of any type or within a partially known sequence.\n* an *empty value* is used in the case of insertions with the maximally\n  trimmed, inserted sequence being indicated in `AlternateBases`.",
@@ -557,10 +557,10 @@
         "variation": {
             "oneOf": [
                 {
-                    "$ref": "https://raw.githubusercontent.com/ga4gh/vrs/1.2/schema/vrs.json#/definitions/MolecularVariation"
+                    "$ref": "https://w3id.org/ga4gh/schema/vrs/1.2/vrs.json#/definitions/MolecularVariation"
                 },
                 {
-                    "$ref": "https://raw.githubusercontent.com/ga4gh/vrs/1.2/schema/vrs.json#/definitions/SystemicVariation"
+                    "$ref": "https://w3id.org/ga4gh/schema/vrs/1.2/vrs.json#/definitions/SystemicVariation"
                 },
                 {
                     "$ref": "#/$defs/LegacyVariation"

--- a/models/src/beacon-v2-default-model/genomicVariations/defaultSchema.yaml
+++ b/models/src/beacon-v2-default-model/genomicVariations/defaultSchema.yaml
@@ -10,8 +10,8 @@ required:
 properties:
   variation:
     oneOf:
-      - $ref: https://raw.githubusercontent.com/ga4gh/vrs/1.2/schema/vrs.json#/definitions/MolecularVariation
-      - $ref: https://raw.githubusercontent.com/ga4gh/vrs/1.2/schema/vrs.json#/definitions/SystemicVariation
+      - $ref: https://w3id.org/ga4gh/schema/vrs/1.2/vrs.json#/definitions/MolecularVariation
+      - $ref: https://w3id.org/ga4gh/schema/vrs/1.2/vrs.json#/definitions/SystemicVariation
       - $ref: '#/$defs/LegacyVariation'
   variantInternalId:
     description: >-
@@ -51,7 +51,7 @@ $defs:
       - location
     properties:
       location:
-        $ref: https://raw.githubusercontent.com/ga4gh/vrs/main/schema/vrs.json#/definitions/Location
+        $ref: https://w3id.org/ga4gh/schema/vrs/1.2/vrs.json#/definitions/Location
       variantType:
         description: >-
           The `variantType` declares the nature of the variation in relation


### PR DESCRIPTION
Following discussions with and new links provided by @ahwagner this fixes the broken

`https://raw.githubusercontent.com/ga4gh/vrs/1.2/schema/vrs.json`

entries to the now canonical

`https://w3id.org/ga4gh/schema/vrs/1.2/vrs.json`

A separate change should consider updating the VRS references from 1.2 => 1.3 (before a general variant format update to 2.x).