### PR TITLE
Add 'filtersLogic' property

### DIFF
--- a/framework/json/requests/beaconRequestBody.json
+++ b/framework/json/requests/beaconRequestBody.json
@@ -7,6 +7,10 @@
                     "$ref": "./filteringTerms.json",
                     "description": "Ontology based filters. Using CURIE syntax is encouraged."
                 },
+                "filtersLogic": {
+                    "type": "string",
+                    "description": "Logical query applied to the filters."
+                },
                 "includeResultsetResponses": {
                     "$ref": "../common/beaconCommonComponents.json#/$defs/IncludeResultsetResponses"
                 },

--- a/framework/src/requests/beaconRequestBody.yaml
+++ b/framework/src/requests/beaconRequestBody.yaml
@@ -27,6 +27,10 @@ $defs:
         description: >-
           Ontology based filters. Using CURIE syntax is encouraged.
         $ref: ./filteringTerms.yaml
+      filtersLogic:
+        description: >-
+          Logical query applied to the filters.
+        type: string
       includeResultsetResponses:
         $ref: ../common/beaconCommonComponents.yaml#/$defs/IncludeResultsetResponses
       pagination:


### PR DESCRIPTION
This is a BSC's Logical Filters proposal for the Beacons Queries.

Currently, Beacon v2 (and 2.1) specification applies filters as a logical intersection (AND). Nevertheless, some queries  may require more complex conditions like logical unions (OR) or negations (NOT). Imagine a researcher is looking for the medical condition that includes either 'Nonalcoholic fatty liver disease' (SNOMED:197315008)  or 'Hepatic fibrosis' (SNOMED:62484002). It is also may be plausible to be able to exclude some conditions (e.g. no Hepatitis) from the search.

Beacon Filtering Scouts have been discussed several possibilities no include such a functionality into the Beacon specification.
Here is one proposal that we believe is quite simple to be implemented by Beacon's developers.
Basically it consists in adding an additional optional property `"filtersLogic"` into the "BeaconQuery" object.
The query must support all three logical operations (**&** - 'AND', **|** - 'OR' and **!** - 'NOT') as well as parenthesis for grouping. Without parenthesis the sequence of logical operators should follow the standard flow where precedence is defined as '**NOT**' then '**AND**' then '**OR**' operators.
All filter identifiers **MUST** be present in the `"filters"` property of the query.

Example (from [presentation](https://docs.google.com/presentation/d/1h4g_R2aSSfUdjWNzKopu8Cg1bh7q0LVzIMxOF_g4dj0/edit#slide=id.g2b86397cbd2_3_79)):
```json
"query": {
  "filters": [
    { "id": "NCIT:C20197" },
    { "id": "Weight",
      "operator": ">",
      "value": "80"
    },
    { "id": "BMI",
      "operator": ">",
      "value": "25"
    }
  ],
  "filtersLogic": "NCIT:C20197 & !(Weight & !BMI)",
```

Some previous discussions: https://github.com/ga4gh-beacon/beacon-v2/issues/63