### PR TITLE
Generic Resultsets

### DIFF
--- a/framework/json/responses/sections/beaconResultsets.json
+++ b/framework/json/responses/sections/beaconResultsets.json
@@ -16,8 +16,14 @@
                     "type": "object"
                 },
                 "results": {
+                    "$defs": {
+                        "defaultResultsEntryType": {
+                            "$dynamicAnchor": "resultsEntryType",
+                            "type": "object"
+                        }
+                    },
                     "items": {
-                        "type": "object"
+                        "$dynamicRef": "#resultsEntryType"
                     },
                     "minItems": 0,
                     "type": "array"

--- a/framework/src/responses/sections/beaconResultsets.yaml
+++ b/framework/src/responses/sections/beaconResultsets.yaml
@@ -41,9 +41,13 @@ $defs:
           specification.
         type: object
       results:
+        $defs:
+          defaultResultsEntryType:
+            $dynamicAnchor: resultsEntryType
+            type: object
         type: array
         items:
-          type: object
+          $dynamicRef: #resultsEntryType
         minItems: 0
     required:
       - id


### PR DESCRIPTION
This commit open a possibility to redefine the Resultset content (e.g. specify that the message content is a 'biosamples' object).