### PR TITLE
documentation for /filtering_terms values field

### DIFF
--- a/docs/filters.md
+++ b/docs/filters.md
@@ -65,13 +65,15 @@ Alphanumerical value Filter types contain:
 * `type` = data type as 'alphanumeric' (required) 
 * `id` = field id (required) 
 * `label` = field label (optional) 
+* `values` = an array of possible values for this id (optional)
 
 ```json
 "filteringTerms": [
 	{
 		"type": "alphanumeric",
-		"id": "PATO:0000011",
-		"label": "age"
+		"id": "geographicOrigin",
+		"label": "Geographic Origin",
+		"values": ["Eurasia", "Municipality of El Masnou", "Slovenia", "United States of America"]
 	}
 ]
 ```


### PR DESCRIPTION
As promised, documentation for the filtering terms `values` field added in #160. The example values are pulled from examples in the schema, I can simplify them if they seem a bit absurd. 

Note that this changes the "id" from a CURIE to a field in the model, which better reflects how this filter is used, both in the specification and the reference implementation.