### PR TITLE
fix complexValue example

### DIFF
--- a/models/json/beacon-v2-default-model/common/complexValue.json
+++ b/models/json/beacon-v2-default-model/common/complexValue.json
@@ -6,12 +6,11 @@
                     "$ref": "./quantity.json",
                     "description": "Quantity denoting the outcome of the measurement",
                     "example": {
-                        "quentity": {
-                            "unit": {
-                                "id": "NCIT:C49670",
-                                "label": "Millimeter of Mercury"
-                            }
-                        }
+                        "unit": {
+                            "id": "NCIT:C49670",
+                            "label": "Millimeter of Mercury"
+                        },
+                        "value": 110
                     }
                 },
                 "quantityType": {

--- a/models/src/beacon-v2-default-model/common/complexValue.yaml
+++ b/models/src/beacon-v2-default-model/common/complexValue.yaml
@@ -26,10 +26,10 @@ $defs:
         description: Quantity denoting the outcome of the measurement
         $ref: ./quantity.yaml
         example:
-          quentity:
-            unit:
-              id: NCIT:C49670
-              label: Millimeter of Mercury
+          unit:
+            id: NCIT:C49670
+            label: Millimeter of Mercury
+          value: 110
     required:
       - quantityType
       - quantity


### PR DESCRIPTION
Fixes to complexValue example:
- removed extra nesting that shouldn't be there (it was also mispelled as "quentity", but it shouldn't be there at all: `quantity` does not a have sub-field called "quantity"
- added `value`, which is a required field