### PR TITLE
Revert "Changing measures to measurements in individuals"

### DIFF
--- a/models/json/beacon-v2-default-model/individuals/defaultSchema.json
+++ b/models/json/beacon-v2-default-model/individuals/defaultSchema.json
@@ -43,7 +43,7 @@
             "$ref": "../common/commonDefinitions.json#/$defs/KaryotypicSex",
             "description": "The chromosomal sex of an individual represented from a selection of options."
         },
-        "measurements": {
+        "measures": {
             "items": {
                 "$ref": "../common/measurement.json"
             },

--- a/models/src/beacon-v2-default-model/individuals/defaultSchema.yaml
+++ b/models/src/beacon-v2-default-model/individuals/defaultSchema.yaml
@@ -53,7 +53,7 @@ properties:
     type: array
     items:
       $ref: ../common/procedure.yaml
-  measurements:
+  measures:
     type: array
     items:
       $ref: ../common/measurement.yaml


### PR DESCRIPTION
Reverts ga4gh-beacon/beacon-v2#226 ... since there are `measures` still in docs and deref'd schemas. Will fix & redo.