### PR TITLE
separate xxxResultsetInstance types

### DIFF
--- a/framework/json/responses/sections/beaconResultsets.json
+++ b/framework/json/responses/sections/beaconResultsets.json
@@ -18,6 +18,10 @@
                     "$ref": "../../common/beaconCommonComponents.json#/$defs/ListOfHandovers",
                     "description": "List of handover objects that apply to this resultset, not to the whole Beacon or to a result in particular."
                 },
+                "resultsetGranularity": {
+                    "const": "boolean",
+                    "type": "string"
+                },
                 "setType": {
                     "default": "dataset",
                     "description": "Entry type of resultSet. It SHOULD MATCH an entry type declared as collection in the Beacon configuration.",
@@ -27,6 +31,7 @@
             "required": [
                 "id",
                 "setType",
+                "resultsetGranularity",
                 "exists"
             ],
             "type": "object"
@@ -53,6 +58,10 @@
                     "$ref": "../../common/beaconCommonComponents.json#/$defs/ListOfHandovers",
                     "description": "List of handovers that apply to this resultset, not to the whole Beacon or to a result in particular."
                 },
+                "resultsetGranularity": {
+                    "const": "count",
+                    "type": "string"
+                },
                 "setType": {
                     "default": "dataset",
                     "description": "Entry type of resultSet. It SHOULD MATCH an entry type declared as collection in the Beacon configuration.",
@@ -62,6 +71,7 @@
             "required": [
                 "id",
                 "setType",
+                "resultsetGranularity",
                 "exists",
                 "resultsCount"
             ],
@@ -96,6 +106,10 @@
                     "$ref": "../../common/beaconCommonComponents.json#/$defs/ListOfHandovers",
                     "description": "List of handovers that apply to this resultset, not to the whole Beacon or to a result in particular."
                 },
+                "resultsetGranularity": {
+                    "const": "record",
+                    "type": "string"
+                },
                 "setType": {
                     "default": "dataset",
                     "description": "Entry type of resultSet. It SHOULD MATCH an entry type declared as collection in the Beacon configuration.",
@@ -105,6 +119,7 @@
             "required": [
                 "id",
                 "setType",
+                "resultsetGranularity",
                 "exists",
                 "resultsCount",
                 "results"

--- a/framework/json/responses/sections/beaconResultsets.json
+++ b/framework/json/responses/sections/beaconResultsets.json
@@ -1,6 +1,6 @@
 {
     "$defs": {
-        "ResultsetInstance": {
+        "BooleanResultsetInstance": {
             "additionalProperties": true,
             "properties": {
                 "exists": {
@@ -12,8 +12,74 @@
                     "type": "string"
                 },
                 "info": {
-                    "description": "Additional details that could be of interest about the Resultset. Provided to clearly enclose any attribute that is not part of the Beacon specification.",
-                    "type": "object"
+                    "$ref": "../../common/info.json"
+                },
+                "resultsHandovers": {
+                    "$ref": "../../common/beaconCommonComponents.json#/$defs/ListOfHandovers",
+                    "description": "List of handover objects that apply to this resultset, not to the whole Beacon or to a result in particular."
+                },
+                "setType": {
+                    "default": "dataset",
+                    "description": "Entry type of resultSet. It SHOULD MATCH an entry type declared as collection in the Beacon configuration.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "id",
+                "setType",
+                "exists"
+            ],
+            "type": "object"
+        },
+        "CountResultsetInstance": {
+            "additionalProperties": true,
+            "properties": {
+                "exists": {
+                    "type": "boolean"
+                },
+                "id": {
+                    "description": "id of the resultset",
+                    "example": "datasetA",
+                    "type": "string"
+                },
+                "info": {
+                    "$ref": "../../common/info.json"
+                },
+                "resultsCount": {
+                    "description": "Number of results in this Resultset.",
+                    "type": "integer"
+                },
+                "resultsHandovers": {
+                    "$ref": "../../common/beaconCommonComponents.json#/$defs/ListOfHandovers",
+                    "description": "List of handovers that apply to this resultset, not to the whole Beacon or to a result in particular."
+                },
+                "setType": {
+                    "default": "dataset",
+                    "description": "Entry type of resultSet. It SHOULD MATCH an entry type declared as collection in the Beacon configuration.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "id",
+                "setType",
+                "exists",
+                "resultsCount"
+            ],
+            "type": "object"
+        },
+        "RecordsResultsetInstance": {
+            "additionalProperties": true,
+            "properties": {
+                "exists": {
+                    "type": "boolean"
+                },
+                "id": {
+                    "description": "id of the resultset",
+                    "example": "datasetA",
+                    "type": "string"
+                },
+                "info": {
+                    "$ref": "../../common/info.json"
                 },
                 "results": {
                     "items": {
@@ -55,7 +121,17 @@
         },
         "resultSets": {
             "items": {
-                "$ref": "#/$defs/ResultsetInstance"
+                "oneOf": [
+                    {
+                        "$ref": "#/$defs/BooleanResultsetInstance"
+                    },
+                    {
+                        "$ref": "#/$defs/CountResultsetInstance"
+                    },
+                    {
+                        "$ref": "#/$defs/RecordsResultsetInstance"
+                    }
+                ]
             },
             "minItems": 0,
             "type": "array"

--- a/framework/json/responses/sections/beaconResultsets.json
+++ b/framework/json/responses/sections/beaconResultsets.json
@@ -110,6 +110,19 @@
                 "results"
             ],
             "type": "object"
+        },
+        "ResultsetInstance": {
+            "oneOf": [
+                {
+                    "$ref": "#/$defs/BooleanResultsetInstance"
+                },
+                {
+                    "$ref": "#/$defs/CountResultsetInstance"
+                },
+                {
+                    "$ref": "#/$defs/RecordsResultsetInstance"
+                }
+            ]
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -121,17 +134,7 @@
         },
         "resultSets": {
             "items": {
-                "oneOf": [
-                    {
-                        "$ref": "#/$defs/BooleanResultsetInstance"
-                    },
-                    {
-                        "$ref": "#/$defs/CountResultsetInstance"
-                    },
-                    {
-                        "$ref": "#/$defs/RecordsResultsetInstance"
-                    }
-                ]
+                "$ref": "#/$defs/ResultsetInstance"
             },
             "minItems": 0,
             "type": "array"

--- a/framework/src/responses/sections/beaconResultsets.yaml
+++ b/framework/src/responses/sections/beaconResultsets.yaml
@@ -34,6 +34,9 @@ $defs:
           as collection in the Beacon configuration.
         type: string
         default: dataset
+      resultsetGranularity:
+        type: string
+        const: boolean      
       exists:
         type: boolean
       resultsHandovers:
@@ -46,6 +49,7 @@ $defs:
     required:
       - id
       - setType
+      - resultsetGranularity
       - exists
     additionalProperties: true
 
@@ -62,6 +66,9 @@ $defs:
           as collection in the Beacon configuration.
         type: string
         default: dataset
+      resultsetGranularity:
+        type: string
+        const: count      
       exists:
         type: boolean
       resultsCount:
@@ -76,6 +83,7 @@ $defs:
     required:
       - id
       - setType
+      - resultsetGranularity
       - exists
       - resultsCount
     additionalProperties: true
@@ -93,6 +101,9 @@ $defs:
           as collection in the Beacon configuration.
         type: string
         default: dataset
+      resultsetGranularity:
+        type: string
+        const: record      
       exists:
         type: boolean
       resultsCount:
@@ -112,6 +123,7 @@ $defs:
     required:
       - id
       - setType
+      - resultsetGranularity
       - exists
       - resultsCount
       - results

--- a/framework/src/responses/sections/beaconResultsets.yaml
+++ b/framework/src/responses/sections/beaconResultsets.yaml
@@ -8,15 +8,19 @@ properties:
   resultSets:
     type: array
     items:
-      oneOf:
-        - $ref: '#/$defs/BooleanResultsetInstance'
-        - $ref: '#/$defs/CountResultsetInstance'
-        - $ref: '#/$defs/RecordsResultsetInstance'
+      $ref: '#/$defs/ResultsetInstance'
     minItems: 0
 required:
   - resultSets
 additionalProperties: true
+
 $defs:
+  ResultsetInstance:
+    oneOf:
+      - $ref: '#/$defs/BooleanResultsetInstance'
+      - $ref: '#/$defs/CountResultsetInstance'
+      - $ref: '#/$defs/RecordsResultsetInstance'
+
   BooleanResultsetInstance:
     type: object
     properties:

--- a/framework/src/responses/sections/beaconResultsets.yaml
+++ b/framework/src/responses/sections/beaconResultsets.yaml
@@ -8,13 +8,16 @@ properties:
   resultSets:
     type: array
     items:
-      $ref: '#/$defs/ResultsetInstance'
+      oneOf:
+        - $ref: '#/$defs/BooleanResultsetInstance'
+        - $ref: '#/$defs/CountResultsetInstance'
+        - $ref: '#/$defs/RecordsResultsetInstance'
     minItems: 0
 required:
   - resultSets
 additionalProperties: true
 $defs:
-  ResultsetInstance:
+  BooleanResultsetInstance:
     type: object
     properties:
       id:
@@ -22,7 +25,36 @@ $defs:
         type: string
         example: datasetA
       setType:
-        description: Entry type of resultSet. It SHOULD MATCH an entry type declared
+        description: >-
+          Entry type of resultSet. It SHOULD MATCH an entry type declared
+          as collection in the Beacon configuration.
+        type: string
+        default: dataset
+      exists:
+        type: boolean
+      resultsHandovers:
+        description: >-
+          List of handover objects that apply to this resultset, not to the whole
+          Beacon or to a result in particular.
+        $ref: ../../common/beaconCommonComponents.yaml#/$defs/ListOfHandovers
+      info:
+        $ref: ../../common/info.yaml
+    required:
+      - id
+      - setType
+      - exists
+    additionalProperties: true
+
+  CountResultsetInstance:
+    type: object
+    properties:
+      id:
+        description: id of the resultset
+        type: string
+        example: datasetA
+      setType:
+        description: >-
+          Entry type of resultSet. It SHOULD MATCH an entry type declared
           as collection in the Beacon configuration.
         type: string
         default: dataset
@@ -36,10 +68,38 @@ $defs:
           Beacon or to a result in particular.
         $ref: ../../common/beaconCommonComponents.yaml#/$defs/ListOfHandovers
       info:
-        description: Additional details that could be of interest about the Resultset.
-          Provided to clearly enclose any attribute that is not part of the Beacon
-          specification.
-        type: object
+        $ref: ../../common/info.yaml
+    required:
+      - id
+      - setType
+      - exists
+      - resultsCount
+    additionalProperties: true
+
+  RecordsResultsetInstance:
+    type: object
+    properties:
+      id:
+        description: id of the resultset
+        type: string
+        example: datasetA
+      setType:
+        description: >-
+          Entry type of resultSet. It SHOULD MATCH an entry type declared
+          as collection in the Beacon configuration.
+        type: string
+        default: dataset
+      exists:
+        type: boolean
+      resultsCount:
+        description: Number of results in this Resultset.
+        type: integer
+      resultsHandovers:
+        description: List of handovers that apply to this resultset, not to the whole
+          Beacon or to a result in particular.
+        $ref: ../../common/beaconCommonComponents.yaml#/$defs/ListOfHandovers
+      info:
+        $ref: ../../common/info.yaml
       results:
         type: array
         items:


### PR DESCRIPTION
```
  resultSets:
    type: array
    items:
      oneOf:
        - $ref: '#/$defs/BooleanResultsetInstance'
        - $ref: '#/$defs/CountResultsetInstance'
        - $ref: '#/$defs/RecordsResultsetInstance'
```

This is an attempt to address the problem of Boolean and count resultSets discused in https://github.com/ga4gh-beacon/beacon-v2/discussions/222 . Should actually be non-breaking.

Also changes `info` to point to the prototype definition.