### PR TITLE
de-restricting Resultset formats

### DIFF
--- a/framework/json/responses/sections/beaconResultsets.json
+++ b/framework/json/responses/sections/beaconResultsets.json
@@ -12,8 +12,7 @@
                     "type": "string"
                 },
                 "info": {
-                    "description": "Additional details that could be of interest about the Resultset. Provided to clearly enclose any attribute that is not part of the Beacon specification.",
-                    "type": "object"
+                    "$ref": "../../common/info.json"
                 },
                 "results": {
                     "items": {
@@ -28,7 +27,7 @@
                 },
                 "resultsHandovers": {
                     "$ref": "../../common/beaconCommonComponents.json#/$defs/ListOfHandovers",
-                    "description": "List of handovers that apply to this resultset, not to the whole Beacon or to a result in particular."
+                    "description": "List of handover objects that apply to this resultset, not to the whole Beacon or to a result in particular."
                 },
                 "setType": {
                     "default": "dataset",
@@ -39,9 +38,7 @@
             "required": [
                 "id",
                 "setType",
-                "exists",
-                "resultsCount",
-                "results"
+                "exists"
             ],
             "type": "object"
         }

--- a/framework/src/responses/sections/beaconResultsets.yaml
+++ b/framework/src/responses/sections/beaconResultsets.yaml
@@ -22,7 +22,8 @@ $defs:
         type: string
         example: datasetA
       setType:
-        description: Entry type of resultSet. It SHOULD MATCH an entry type declared
+        description: >-
+          Entry type of resultSet. It SHOULD MATCH an entry type declared
           as collection in the Beacon configuration.
         type: string
         default: dataset
@@ -32,14 +33,12 @@ $defs:
         description: Number of results in this Resultset.
         type: integer
       resultsHandovers:
-        description: List of handovers that apply to this resultset, not to the whole
+        description: >-
+          List of handover objects that apply to this resultset, not to the whole
           Beacon or to a result in particular.
         $ref: ../../common/beaconCommonComponents.yaml#/$defs/ListOfHandovers
       info:
-        description: Additional details that could be of interest about the Resultset.
-          Provided to clearly enclose any attribute that is not part of the Beacon
-          specification.
-        type: object
+        $ref: ../../common/info.yaml
       results:
         type: array
         items:
@@ -49,6 +48,4 @@ $defs:
       - id
       - setType
       - exists
-      - resultsCount
-      - results
     additionalProperties: true


### PR DESCRIPTION
This removes the requirement for count and results from resultset instances. It provides a simple alternative to https://github.com/ga4gh-beacon/beacon-v2/pull/230. This allows the return of boolean or count resultsets and leaves the interpretation to the consumer.

Either https://github.com/ga4gh-beacon/beacon-v2/pull/230 or this PR should be pursued (independent of additional measures).