### PR TITLE
consistent relative framework $ref in endpoints

### DIFF
--- a/framework/json/responses/sections/beaconInfoResults.json
+++ b/framework/json/responses/sections/beaconInfoResults.json
@@ -61,7 +61,7 @@
             "description": "The date/time the Beacon was created (ISO 8601 format).",
             "examples": [
                 "2014-07-19",
-                "2017-01-17 20:33:40"
+                "2017-01-17 20:33:40+00:00"
             ],
             "type": "string"
         },
@@ -100,7 +100,7 @@
             "description": "The time the Beacon was updated in (ISO 8601 format).",
             "examples": [
                 "2014-07-19",
-                "2017-01-17 20:33:40"
+                "2017-01-17 20:33:40+00:00"
             ],
             "type": "string"
         },

--- a/models/json/beacon-v2-default-model/analyses/endpoints.json
+++ b/models/json/beacon-v2-default-model/analyses/endpoints.json
@@ -30,14 +30,14 @@
                 "in": "query",
                 "name": "includeResultsetResponses",
                 "schema": {
-                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/IncludeResultsetResponses"
+                    "$ref": "../../../../framework/json/common/beaconCommonComponents.json#/definitions/IncludeResultsetResponses"
                 }
             },
             "limit": {
                 "in": "query",
                 "name": "limit",
                 "schema": {
-                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Limit"
+                    "$ref": "../../../../framework/json/common/beaconCommonComponents.json#/$defs/Limit"
                 }
             },
             "requestedSchema": {
@@ -54,7 +54,7 @@
                 "in": "query",
                 "name": "skip",
                 "schema": {
-                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Skip"
+                    "$ref": "../../../../framework/json/common/beaconCommonComponents.json#/$defs/Skip"
                 }
             }
         },
@@ -65,13 +65,13 @@
                         "schema": {
                             "oneOf": [
                                 {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconBooleanResponse.json"
+                                    "$ref": "../../../../framework/json/responses/beaconBooleanResponse.json"
                                 },
                                 {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconCountResponse.json"
+                                    "$ref": "../../../../framework/json/responses/beaconCountResponse.json"
                                 },
                                 {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconResultsetsResponse.json"
+                                    "$ref": "../../../../framework/json/responses/beaconResultsetsResponse.json"
                                 }
                             ]
                         }
@@ -121,7 +121,7 @@
                         "$ref": "#/components/responses/ResultsOKResponse"
                     },
                     "default": {
-                        "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                        "$ref": "../../../../framework/json/responses/beaconErrorResponse.json"
                     }
                 },
                 "tags": [
@@ -135,7 +135,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/requests/beaconRequestBody.json"
+                                "$ref": "../../../../framework/json/requests/beaconRequestBody.json"
                             }
                         }
                     },
@@ -146,7 +146,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconResultsetsResponse.json"
+                                    "$ref": "../../../../framework/json/responses/beaconResultsetsResponse.json"
                                 }
                             }
                         },
@@ -156,7 +156,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },
@@ -180,7 +180,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },
@@ -203,7 +203,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/requests/beaconRequestBody.json"
+                                "$ref": "../../../../framework/json/requests/beaconRequestBody.json"
                             }
                         }
                     },
@@ -217,7 +217,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },
@@ -252,7 +252,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },
@@ -275,7 +275,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/requests/beaconRequestBody.json"
+                                "$ref": "../../../../framework/json/requests/beaconRequestBody.json"
                             }
                         }
                     },
@@ -289,7 +289,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },

--- a/models/json/beacon-v2-default-model/biosamples/endpoints.json
+++ b/models/json/beacon-v2-default-model/biosamples/endpoints.json
@@ -40,14 +40,14 @@
                 "in": "query",
                 "name": "includeResultsetResponses",
                 "schema": {
-                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/IncludeResultsetResponses"
+                    "$ref": "../../../../framework/json/common/beaconCommonComponents.json#/definitions/IncludeResultsetResponses"
                 }
             },
             "limit": {
                 "in": "query",
                 "name": "limit",
                 "schema": {
-                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Limit"
+                    "$ref": "../../../../framework/json/common/beaconCommonComponents.json#/$defs/Limit"
                 }
             },
             "requestedSchema": {
@@ -64,7 +64,7 @@
                 "in": "query",
                 "name": "skip",
                 "schema": {
-                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Skip"
+                    "$ref": "../../../../framework/json/common/beaconCommonComponents.json#/$defs/Skip"
                 }
             }
         },
@@ -159,7 +159,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },
@@ -183,7 +183,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },
@@ -220,7 +220,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },
@@ -255,7 +255,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },
@@ -292,7 +292,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },
@@ -327,7 +327,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },
@@ -364,7 +364,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },
@@ -406,7 +406,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },
@@ -450,7 +450,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },

--- a/models/json/beacon-v2-default-model/cohorts/endpoints.json
+++ b/models/json/beacon-v2-default-model/cohorts/endpoints.json
@@ -30,7 +30,7 @@
                 "in": "query",
                 "name": "limit",
                 "schema": {
-                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Limit"
+                    "$ref": "../../../../framework/json/common/beaconCommonComponents.json#/$defs/Limit"
                 }
             },
             "requestedSchema": {
@@ -47,7 +47,7 @@
                 "in": "query",
                 "name": "skip",
                 "schema": {
-                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Skip"
+                    "$ref": "../../../../framework/json/common/beaconCommonComponents.json#/$defs/Skip"
                 }
             }
         },
@@ -159,7 +159,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },
@@ -188,7 +188,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },
@@ -225,7 +225,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },
@@ -264,7 +264,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },
@@ -308,7 +308,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },
@@ -343,7 +343,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },
@@ -380,7 +380,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },

--- a/models/json/beacon-v2-default-model/datasets/endpoints.json
+++ b/models/json/beacon-v2-default-model/datasets/endpoints.json
@@ -30,7 +30,7 @@
                 "in": "query",
                 "name": "limit",
                 "schema": {
-                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Limit"
+                    "$ref": "../../../../framework/json/common/beaconCommonComponents.json#/$defs/Limit"
                 }
             },
             "requestedSchema": {
@@ -47,7 +47,7 @@
                 "in": "query",
                 "name": "skip",
                 "schema": {
-                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Skip"
+                    "$ref": "../../../../framework/json/common/beaconCommonComponents.json#/$defs/Skip"
                 }
             }
         },
@@ -159,7 +159,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },
@@ -188,7 +188,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },
@@ -225,7 +225,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },
@@ -260,7 +260,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },
@@ -297,7 +297,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },
@@ -336,7 +336,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },
@@ -380,7 +380,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },
@@ -415,7 +415,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },
@@ -452,7 +452,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },
@@ -487,7 +487,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },
@@ -524,7 +524,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },

--- a/models/json/beacon-v2-default-model/endpoints.json
+++ b/models/json/beacon-v2-default-model/endpoints.json
@@ -5,7 +5,7 @@
                 "in": "query",
                 "name": "limit",
                 "schema": {
-                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Limit"
+                    "$ref": "../../../framework/json/common/beaconCommonComponents.json#/$defs/Limit"
                 }
             },
             "requestedSchema": {
@@ -22,7 +22,7 @@
                 "in": "query",
                 "name": "skip",
                 "schema": {
-                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Skip"
+                    "$ref": "../../../framework/json/common/beaconCommonComponents.json#/$defs/Skip"
                 }
             }
         },
@@ -66,7 +66,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },
@@ -103,7 +103,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },
@@ -136,7 +136,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },
@@ -157,7 +157,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconFilteringTermsResponse.json"
+                                    "$ref": "../../../framework/json/responses/beaconFilteringTermsResponse.json"
                                 }
                             }
                         },
@@ -167,7 +167,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },
@@ -199,7 +199,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },
@@ -237,7 +237,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },

--- a/models/json/beacon-v2-default-model/genomicVariations/endpoints.json
+++ b/models/json/beacon-v2-default-model/genomicVariations/endpoints.json
@@ -92,14 +92,14 @@
                 "in": "query",
                 "name": "includeResultsetResponses",
                 "schema": {
-                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/IncludeResultsetResponses"
+                    "$ref": "../../../../framework/json/common/beaconCommonComponents.json#/definitions/IncludeResultsetResponses"
                 }
             },
             "limit": {
                 "in": "query",
                 "name": "limit",
                 "schema": {
-                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Limit"
+                    "$ref": "../../../../framework/json/common/beaconCommonComponents.json#/$defs/Limit"
                 }
             },
             "referenceBases": {
@@ -130,7 +130,7 @@
                 "in": "query",
                 "name": "skip",
                 "schema": {
-                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Skip"
+                    "$ref": "../../../../framework/json/common/beaconCommonComponents.json#/$defs/Skip"
                 }
             },
             "start": {
@@ -290,7 +290,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },
@@ -314,7 +314,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },
@@ -351,7 +351,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },
@@ -386,7 +386,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },
@@ -423,7 +423,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },
@@ -458,7 +458,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },
@@ -495,7 +495,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },

--- a/models/json/beacon-v2-default-model/individuals/endpoints.json
+++ b/models/json/beacon-v2-default-model/individuals/endpoints.json
@@ -30,14 +30,14 @@
                 "in": "query",
                 "name": "includeResultsetResponses",
                 "schema": {
-                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/IncludeResultsetResponses"
+                    "$ref": "../../../../framework/json/common/beaconCommonComponents.json#/definitions/IncludeResultsetResponses"
                 }
             },
             "limit": {
                 "in": "query",
                 "name": "limit",
                 "schema": {
-                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Limit"
+                    "$ref": "../../../../framework/json/common/beaconCommonComponents.json#/$defs/Limit"
                 }
             },
             "requestedSchema": {
@@ -54,7 +54,7 @@
                 "in": "query",
                 "name": "skip",
                 "schema": {
-                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Skip"
+                    "$ref": "../../../../framework/json/common/beaconCommonComponents.json#/$defs/Skip"
                 }
             }
         },
@@ -149,7 +149,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },
@@ -188,7 +188,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },
@@ -227,7 +227,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },
@@ -251,7 +251,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },
@@ -288,7 +288,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },
@@ -323,7 +323,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },
@@ -360,7 +360,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },
@@ -395,7 +395,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },
@@ -432,7 +432,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },

--- a/models/json/beacon-v2-default-model/runs/endpoints.json
+++ b/models/json/beacon-v2-default-model/runs/endpoints.json
@@ -38,7 +38,7 @@
                 "in": "query",
                 "name": "includeResultsetResponses",
                 "schema": {
-                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/IncludeResultsetResponses"
+                    "$ref": "../../../../framework/json/common/beaconCommonComponents.json#/definitions/IncludeResultsetResponses"
                 }
             },
             "individualId": {
@@ -53,7 +53,7 @@
                 "in": "query",
                 "name": "limit",
                 "schema": {
-                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Limit"
+                    "$ref": "../../../../framework/json/common/beaconCommonComponents.json#/$defs/Limit"
                 }
             },
             "requestedSchema": {
@@ -70,7 +70,7 @@
                 "in": "query",
                 "name": "skip",
                 "schema": {
-                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Skip"
+                    "$ref": "../../../../framework/json/common/beaconCommonComponents.json#/$defs/Skip"
                 }
             }
         },
@@ -165,7 +165,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },
@@ -189,7 +189,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },
@@ -226,7 +226,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },
@@ -261,7 +261,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },
@@ -298,7 +298,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },
@@ -333,7 +333,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },
@@ -370,7 +370,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json"
+                                    "$ref": "../../../../framework/json/responses/beaconErrorResponse.json"
                                 }
                             }
                         },

--- a/models/src/beacon-v2-default-model/analyses/endpoints.yaml
+++ b/models/src/beacon-v2-default-model/analyses/endpoints.yaml
@@ -26,7 +26,7 @@ paths:
         '200':
           $ref: '#/components/responses/ResultsOKResponse'
         default:
-          $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+          $ref: ../../../../framework/json/responses/beaconErrorResponse.json
     post:
       description: Get a Beacon response for bioinformatics analyses
       operationId: postAnalysesRequest
@@ -36,7 +36,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/requests/beaconRequestBody.json
+              $ref: ../../../../framework/json/requests/beaconRequestBody.json
         required: true
       responses:
         '200':
@@ -44,13 +44,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconResultsetsResponse.json
+                $ref: ../../../../framework/json/responses/beaconResultsetsResponse.json
         default:
           description: An unsuccessful operation
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../../framework/json/responses/beaconErrorResponse.json
   /analyses/{id}:
     parameters:
       - $ref: '#/components/parameters/entryId'
@@ -69,7 +69,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../../framework/json/responses/beaconErrorResponse.json
     post:
       description: >-
         Get details about one bioinformatics analysis, identified by its
@@ -81,7 +81,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/requests/beaconRequestBody.json
+              $ref: ../../../../framework/json/requests/beaconRequestBody.json
         required: true
       responses:
         '200':
@@ -91,7 +91,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../../framework/json/responses/beaconErrorResponse.json
   /analyses/{id}/g_variants:
     parameters:
       - $ref: '#/components/parameters/entryId'
@@ -114,7 +114,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../../framework/json/responses/beaconErrorResponse.json
     post:
       description: >-
         Get a *genomic variations* response for one bioinformatics analysis,
@@ -126,7 +126,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/requests/beaconRequestBody.json
+              $ref: ../../../../framework/json/requests/beaconRequestBody.json
         required: true
       responses:
         '200':
@@ -136,7 +136,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../../framework/json/responses/beaconErrorResponse.json
 components:
   responses:
     ResultsOKResponse:
@@ -145,9 +145,9 @@ components:
         application/json:
           schema:
             oneOf:
-              - $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconBooleanResponse.json
-              - $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconCountResponse.json
-              - $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconResultsetsResponse.json
+              - $ref: ../../../../framework/json/responses/beaconBooleanResponse.json
+              - $ref: ../../../../framework/json/responses/beaconCountResponse.json
+              - $ref: ../../../../framework/json/responses/beaconResultsetsResponse.json
   parameters:
     requestedSchema:
       name: requestedSchema
@@ -162,17 +162,17 @@ components:
       name: skip
       in: query
       schema:
-        $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Skip
+        $ref: ../../../../framework/json/common/beaconCommonComponents.json#/$defs/Skip
     limit:
       name: limit
       in: query
       schema:
-        $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Limit
+        $ref: ../../../../framework/json/common/beaconCommonComponents.json#/$defs/Limit
     includeResultsetResponses:
       name: includeResultsetResponses
       in: query
       schema:
-        $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/IncludeResultsetResponses
+        $ref: ../../../../framework/json/common/beaconCommonComponents.json#/definitions/IncludeResultsetResponses
     entryId:
       name: id
       in: path

--- a/models/src/beacon-v2-default-model/biosamples/endpoints.yaml
+++ b/models/src/beacon-v2-default-model/biosamples/endpoints.yaml
@@ -26,7 +26,7 @@ paths:
         '200':
           $ref: '#/components/responses/ResultsOKResponse'
         default:
-          $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+          $ref: ../../../../framework/json/responses/beaconErrorResponse.json
     post:
       description: Get a Beacon response for biosamples
       operationId: postBiosamplesRequest
@@ -36,7 +36,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/requests/beaconRequestBody.json
+              $ref: ../../../../framework/json/requests/beaconRequestBody.json
         required: true
       responses:
         '200':
@@ -46,7 +46,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../../framework/json/responses/beaconErrorResponse.json
   /biosamples/{id}:
     parameters:
       - $ref: '#/components/parameters/entryId'
@@ -64,7 +64,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../../framework/json/responses/beaconErrorResponse.json
     post:
       description: >-
         Get details about one Biosample, identified by its (unique) 'id'
@@ -75,7 +75,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/requests/beaconRequestBody.json
+              $ref: ../../../../framework/json/requests/beaconRequestBody.json
         required: true
       responses:
         '200':
@@ -85,7 +85,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../../framework/json/responses/beaconErrorResponse.json
   /biosamples/{id}/g_variants:
     parameters:
       - $ref: '#/components/parameters/entryId'
@@ -108,7 +108,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../../framework/json/responses/beaconErrorResponse.json
     post:
       description: >-
         Get a *genomic variations* response from one biosample, identified by
@@ -120,7 +120,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/requests/beaconRequestBody.json
+              $ref: ../../../../framework/json/requests/beaconRequestBody.json
         required: true
       responses:
         '200':
@@ -130,7 +130,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../../framework/json/responses/beaconErrorResponse.json
   /biosamples/{id}/analyses:
     parameters:
       - $ref: '#/components/parameters/entryId'
@@ -153,7 +153,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../../framework/json/responses/beaconErrorResponse.json
     post:
       description: >-
         Get an *analyses* response from one biosample, identified by its
@@ -165,7 +165,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/requests/beaconRequestBody.json
+              $ref: ../../../../framework/json/requests/beaconRequestBody.json
         required: true
       responses:
         '200':
@@ -175,7 +175,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../../framework/json/responses/beaconErrorResponse.json
   /biosamples/{id}/runs:
     parameters:
       - $ref: '#/components/parameters/entryId'
@@ -195,13 +195,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconResultsetsResponse.json
+                $ref: ../../../../framework/json/responses/beaconResultsetsResponse.json
         default:
           description: An unsuccessful operation
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../../framework/json/responses/beaconErrorResponse.json
     post:
       description: >-
         Get a *runs* response from one biosample, identified by its (unique) 'id'
@@ -212,7 +212,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/requests/beaconRequestBody.json
+              $ref: ../../../../framework/json/requests/beaconRequestBody.json
         required: true
       responses:
         '200':
@@ -220,13 +220,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconResultsetsResponse.json
+                $ref: ../../../../framework/json/responses/beaconResultsetsResponse.json
         default:
           description: An unsuccessful operation
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../../framework/json/responses/beaconErrorResponse.json
 components:
   responses:
     ResultsOKResponse:
@@ -235,9 +235,9 @@ components:
         application/json:
           schema:
             oneOf:
-              - $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconBooleanResponse.json
-              - $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconCountResponse.json
-              - $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconResultsetsResponse.json
+              - $ref: ../../../../framework/json/responses/beaconBooleanResponse.json
+              - $ref: ../../../../framework/json/responses/beaconCountResponse.json
+              - $ref: ../../../../framework/json/responses/beaconResultsetsResponse.json
   parameters:
     requestedSchema:
       name: requestedSchema
@@ -252,17 +252,17 @@ components:
       name: skip
       in: query
       schema:
-        $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Skip
+        $ref: ../../../../framework/json/common/beaconCommonComponents.json#/$defs/Skip
     limit:
       name: limit
       in: query
       schema:
-        $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Limit
+        $ref: ../../../../framework/json/common/beaconCommonComponents.json#/$defs/Limit
     includeResultsetResponses:
       name: includeResultsetResponses
       in: query
       schema:
-        $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/IncludeResultsetResponses
+        $ref: ../../../../framework/json/common/beaconCommonComponents.json#/definitions/IncludeResultsetResponses
     entryId:
       name: id
       in: path

--- a/models/src/beacon-v2-default-model/cohorts/endpoints.yaml
+++ b/models/src/beacon-v2-default-model/cohorts/endpoints.yaml
@@ -30,7 +30,7 @@ paths:
         '200':
           $ref: '#/components/responses/CollectionsResponse'
         default:
-          $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+          $ref: ../../../../framework/json/responses/beaconErrorResponse.json
     post:
       description: Get a Beacon *cohorts* response
       operationId: postCohortsRequest
@@ -40,7 +40,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/requests/beaconRequestBody.json
+              $ref: ../../../../framework/json/requests/beaconRequestBody.json
         required: true
       responses:
         '200':
@@ -50,7 +50,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../../framework/json/responses/beaconErrorResponse.json
   /cohorts/{id}:
     parameters:
       - $ref: '#/components/parameters/entryId'
@@ -69,7 +69,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../../framework/json/responses/beaconErrorResponse.json
     post:
       description: Get details about one cohort, identified by its (unique) 'id'
       operationId: postOneCohort
@@ -79,7 +79,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/requests/beaconRequestBody.json
+              $ref: ../../../../framework/json/requests/beaconRequestBody.json
         required: true
       responses:
         '200':
@@ -89,7 +89,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../../framework/json/responses/beaconErrorResponse.json
   /cohorts/{id}/individuals:
     parameters:
       - $ref: '#/components/parameters/entryId'
@@ -112,7 +112,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../../framework/json/responses/beaconErrorResponse.json
     post:
       description: >-
         Get an *individuals* response for one cohort, identified by its (unique)
@@ -124,7 +124,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/requests/beaconRequestBody.json
+              $ref: ../../../../framework/json/requests/beaconRequestBody.json
         required: true
       responses:
         '200':
@@ -134,7 +134,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../../framework/json/responses/beaconErrorResponse.json
   /cohorts/{id}/filtering_terms:
     parameters:
       - $ref: '#/components/parameters/entryId'
@@ -154,13 +154,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconFilteringTermsResponse.json
+                $ref: ../../../../framework/json/responses/beaconFilteringTermsResponse.json
         default:
           description: An unsuccessful operation
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../../framework/json/responses/beaconErrorResponse.json
     post:
       description: >-
         Get a response about the *filtering terms* that could be used with a
@@ -172,7 +172,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/requests/beaconRequestBody.json
+              $ref: ../../../../framework/json/requests/beaconRequestBody.json
         required: true
       responses:
         '200':
@@ -180,13 +180,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconFilteringTermsResponse.json
+                $ref: ../../../../framework/json/responses/beaconFilteringTermsResponse.json
         default:
           description: An unsuccessful operation
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../../framework/json/responses/beaconErrorResponse.json
 components:
   responses:
     ResultsOKResponse:
@@ -195,18 +195,18 @@ components:
         application/json:
           schema:
             oneOf:
-              - $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconBooleanResponse.json
-              - $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconCountResponse.json
-              - $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconResultsetsResponse.json
+              - $ref: ../../../../framework/json/responses/beaconBooleanResponse.json
+              - $ref: ../../../../framework/json/responses/beaconCountResponse.json
+              - $ref: ../../../../framework/json/responses/beaconResultsetsResponse.json
     CollectionsResponse:
       description: Successful collection list operation.
       content:
         application/json:
           schema:
             oneOf:
-              - $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconBooleanResponse.json
-              - $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconCountResponse.json
-              - $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconCollectionsResponse.json
+              - $ref: ../../../../framework/json/responses/beaconBooleanResponse.json
+              - $ref: ../../../../framework/json/responses/beaconCountResponse.json
+              - $ref: ../../../../framework/json/responses/beaconCollectionsResponse.json
   parameters:
     requestedSchema:
       name: requestedSchema
@@ -221,12 +221,12 @@ components:
       name: skip
       in: query
       schema:
-        $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Skip
+        $ref: ../../../../framework/json/common/beaconCommonComponents.json#/$defs/Skip
     limit:
       name: limit
       in: query
       schema:
-        $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Limit
+        $ref: ../../../../framework/json/common/beaconCommonComponents.json#/$defs/Limit
     entryId:
       name: id
       in: path

--- a/models/src/beacon-v2-default-model/datasets/endpoints.yaml
+++ b/models/src/beacon-v2-default-model/datasets/endpoints.yaml
@@ -30,7 +30,7 @@ paths:
         '200':
           $ref: '#/components/responses/CollectionsResponse'
         default:
-          $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+          $ref: ../../../../framework/json/responses/beaconErrorResponse.json
     post:
       description: Get a Beacon *datasets* response
       operationId: postDatasetsRequest
@@ -40,7 +40,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/requests/beaconRequestBody.json
+              $ref: ../../../../framework/json/requests/beaconRequestBody.json
         required: true
       responses:
         '200':
@@ -50,7 +50,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../../framework/json/responses/beaconErrorResponse.json
   /datasets/{id}:
     parameters:
       - $ref: '#/components/parameters/entryId'
@@ -69,7 +69,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../../framework/json/responses/beaconErrorResponse.json
     post:
       description: Get details about one dataset, identified by its (unique) 'id'
       operationId: postOneDataset
@@ -79,7 +79,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/requests/beaconRequestBody.json
+              $ref: ../../../../framework/json/requests/beaconRequestBody.json
         required: true
       responses:
         '200':
@@ -89,7 +89,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../../framework/json/responses/beaconErrorResponse.json
   /datasets/{id}/g_variants:
     parameters:
       - $ref: '#/components/parameters/entryId'
@@ -112,7 +112,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../../framework/json/responses/beaconErrorResponse.json
     post:
       description: >-
         Get a *genomic variations* response for one dataset, identified by its
@@ -124,7 +124,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/requests/beaconRequestBody.json
+              $ref: ../../../../framework/json/requests/beaconRequestBody.json
         required: true
       responses:
         '200':
@@ -134,7 +134,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../../framework/json/responses/beaconErrorResponse.json
   /datasets/{id}/biosamples:
     parameters:
       - $ref: '#/components/parameters/entryId'
@@ -157,7 +157,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../../framework/json/responses/beaconErrorResponse.json
     post:
       description: >-
         Get a *biosamples* response for one dataset, identified by its (unique)
@@ -169,7 +169,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/requests/beaconRequestBody.json
+              $ref: ../../../../framework/json/requests/beaconRequestBody.json
         required: true
       responses:
         '200':
@@ -179,7 +179,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../../framework/json/responses/beaconErrorResponse.json
   /datasets/{id}/individuals:
     parameters:
       - $ref: '#/components/parameters/entryId'
@@ -202,7 +202,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../../framework/json/responses/beaconErrorResponse.json
     post:
       description: >-
         Get an *individuals* response for one dataset, identified by its (unique)
@@ -214,7 +214,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/requests/beaconRequestBody.json
+              $ref: ../../../../framework/json/requests/beaconRequestBody.json
         required: true
       responses:
         '200':
@@ -224,7 +224,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../../framework/json/responses/beaconErrorResponse.json
   /datasets/{id}/filtering_terms:
     parameters:
       - $ref: '#/components/parameters/entryId'
@@ -244,13 +244,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconFilteringTermsResponse.json
+                $ref: ../../../../framework/json/responses/beaconFilteringTermsResponse.json
         default:
           description: An unsuccessful operation
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../../framework/json/responses/beaconErrorResponse.json
     post:
       description: >-
         Get a response about the *filtering terms* that could be used with a
@@ -262,7 +262,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/requests/beaconRequestBody.json
+              $ref: ../../../../framework/json/requests/beaconRequestBody.json
         required: true
       responses:
         '200':
@@ -270,13 +270,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconFilteringTermsResponse.json
+                $ref: ../../../../framework/json/responses/beaconFilteringTermsResponse.json
         default:
           description: An unsuccessful operation
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../../framework/json/responses/beaconErrorResponse.json
 components:
   responses:
     ResultsOKResponse:
@@ -285,18 +285,18 @@ components:
         application/json:
           schema:
             oneOf:
-              - $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconBooleanResponse.json
-              - $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconCountResponse.json
-              - $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconResultsetsResponse.json
+              - $ref: ../../../../framework/json/responses/beaconBooleanResponse.json
+              - $ref: ../../../../framework/json/responses/beaconCountResponse.json
+              - $ref: ../../../../framework/json/responses/beaconResultsetsResponse.json
     CollectionsResponse:
       description: Successful collection list operation.
       content:
         application/json:
           schema:
             oneOf:
-              - $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconBooleanResponse.json
-              - $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconCountResponse.json
-              - $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconCollectionsResponse.json
+              - $ref: ../../../../framework/json/responses/beaconBooleanResponse.json
+              - $ref: ../../../../framework/json/responses/beaconCountResponse.json
+              - $ref: ../../../../framework/json/responses/beaconCollectionsResponse.json
   parameters:
     requestedSchema:
       name: requestedSchema
@@ -311,12 +311,12 @@ components:
       name: skip
       in: query
       schema:
-        $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Skip
+        $ref: ../../../../framework/json/common/beaconCommonComponents.json#/$defs/Skip
     limit:
       name: limit
       in: query
       schema:
-        $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Limit
+        $ref: ../../../../framework/json/common/beaconCommonComponents.json#/$defs/Limit
     entryId:
       name: id
       in: path

--- a/models/src/beacon-v2-default-model/endpoints.yaml
+++ b/models/src/beacon-v2-default-model/endpoints.yaml
@@ -27,7 +27,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../framework/json/responses/beaconErrorResponse.json
   /info:
     parameters:
       - $ref: '#/components/parameters/requestedSchema'
@@ -44,7 +44,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../framework/json/responses/beaconErrorResponse.json
   /service-info:
     get:
       description: Get information about the beacon using GA4GH ServiceInfo format
@@ -57,7 +57,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/ga4gh-service-info-1-0-0-schema.json
+                $ref: ../../../framework/json/responses/ga4gh-service-info-1-0-0-schema.json
   /configuration:
     get:
       description: TBD
@@ -71,13 +71,13 @@ paths:
             application/json:
               schema:
                 description: Response of a request for information about a Beacon
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconConfigurationResponse.json
+                $ref: ../../../framework/json/responses/beaconConfigurationResponse.json
         default:
           description: An unsuccessful operation
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../framework/json/responses/beaconErrorResponse.json
   /entry_types:
     get:
       description: TBD
@@ -92,13 +92,13 @@ paths:
             application/json:
               schema:
                 description: Response of a request for information about a Beacon
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconEntryTypesResponse.json
+                $ref: ../../../framework/json/responses/beaconEntryTypesResponse.json
         default:
           description: An unsuccessful operation
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../framework/json/responses/beaconErrorResponse.json
   /map:
     get:
       description: TBD
@@ -113,13 +113,13 @@ paths:
             application/json:
               schema:
                 description: Response of a request for information about a Beacon
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconMapResponse.json
+                $ref: ../../../framework/json/responses/beaconMapResponse.json
         default:
           description: An unsuccessful operation
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../framework/json/responses/beaconErrorResponse.json
   /filtering_terms:
     parameters:
       - $ref: '#/components/parameters/skip'
@@ -135,13 +135,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconFilteringTermsResponse.json
+                $ref: ../../../framework/json/responses/beaconFilteringTermsResponse.json
         default:
           description: An unsuccessful operation
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../framework/json/responses/beaconErrorResponse.json
 components:
   responses:
     infoOKResponse:
@@ -150,7 +150,7 @@ components:
         application/json:
           schema:
             description: Response of a request for information about a Beacon
-            $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconInfoResponse.json
+            $ref: ../../../framework/json/responses/beaconInfoResponse.json
   parameters:
     requestedSchema:
       name: requestedSchema
@@ -165,9 +165,9 @@ components:
       name: skip
       in: query
       schema:
-        $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Skip
+        $ref: ../../../framework/json/common/beaconCommonComponents.json#/$defs/Skip
     limit:
       name: limit
       in: query
       schema:
-        $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Limit
+        $ref: ../../../framework/json/common/beaconCommonComponents.json#/$defs/Limit

--- a/models/src/beacon-v2-default-model/genomicVariations/endpoints.yaml
+++ b/models/src/beacon-v2-default-model/genomicVariations/endpoints.yaml
@@ -37,7 +37,7 @@ paths:
         '200':
           $ref: '#/components/responses/ResultsOKResponse'
         default:
-          $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+          $ref: ../../../../framework/json/responses/beaconErrorResponse.json
     post:
       description: Get a Beacon response for genomic variations
       operationId: postGenomicVariationsRequest
@@ -47,7 +47,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/requests/beaconRequestBody.json
+              $ref: ../../../../framework/json/requests/beaconRequestBody.json
         required: true
       responses:
         '200':
@@ -57,7 +57,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../../framework/json/responses/beaconErrorResponse.json
   /g_variants/{id}:
     parameters:
       - $ref: '#/components/parameters/entryId'
@@ -75,7 +75,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../../framework/json/responses/beaconErrorResponse.json
     post:
       description: >-
         Get details about one genomic variation, identified by its (unique) 'id'
@@ -86,7 +86,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/requests/beaconRequestBody.json
+              $ref: ../../../../framework/json/requests/beaconRequestBody.json
         required: true
       responses:
         '200':
@@ -96,7 +96,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../../framework/json/responses/beaconErrorResponse.json
   /g_variants/{id}/biosamples:
     parameters:
       - $ref: '#/components/parameters/entryId'
@@ -119,7 +119,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../../framework/json/responses/beaconErrorResponse.json
     post:
       description: >-
         Get a *biosamples* response from one genomic variant, identified by its
@@ -131,7 +131,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/requests/beaconRequestBody.json
+              $ref: ../../../../framework/json/requests/beaconRequestBody.json
         required: true
       responses:
         '200':
@@ -141,7 +141,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../../framework/json/responses/beaconErrorResponse.json
   /g_variants/{id}/individuals:
     parameters:
       - $ref: '#/components/parameters/entryId'
@@ -164,7 +164,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../../framework/json/responses/beaconErrorResponse.json
     post:
       description: >-
         Get an *individuals* response from one genomic variant, identified by
@@ -176,7 +176,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/requests/beaconRequestBody.json
+              $ref: ../../../../framework/json/requests/beaconRequestBody.json
         required: true
       responses:
         '200':
@@ -186,7 +186,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../../framework/json/responses/beaconErrorResponse.json
 components:
   responses:
     ResultsOKResponse:
@@ -195,9 +195,9 @@ components:
         application/json:
           schema:
             oneOf:
-              - $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconBooleanResponse.json
-              - $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconCountResponse.json
-              - $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconResultsetsResponse.json
+              - $ref: ../../../../framework/json/responses/beaconBooleanResponse.json
+              - $ref: ../../../../framework/json/responses/beaconCountResponse.json
+              - $ref: ../../../../framework/json/responses/beaconResultsetsResponse.json
   parameters:
     requestedSchema:
       name: requestedSchema
@@ -212,17 +212,17 @@ components:
       name: skip
       in: query
       schema:
-        $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Skip
+        $ref: ../../../../framework/json/common/beaconCommonComponents.json#/$defs/Skip
     limit:
       name: limit
       in: query
       schema:
-        $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Limit
+        $ref: ../../../../framework/json/common/beaconCommonComponents.json#/$defs/Limit
     includeResultsetResponses:
       name: includeResultsetResponses
       in: query
       schema:
-        $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/IncludeResultsetResponses
+        $ref: ../../../../framework/json/common/beaconCommonComponents.json#/definitions/IncludeResultsetResponses
     entryId:
       name: id
       in: path

--- a/models/src/beacon-v2-default-model/individuals/endpoints.yaml
+++ b/models/src/beacon-v2-default-model/individuals/endpoints.yaml
@@ -26,7 +26,7 @@ paths:
         '200':
           $ref: '#/components/responses/ResultsOKResponse'
         default:
-          $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+          $ref: ../../../../framework/json/responses/beaconErrorResponse.json
     post:
       description: Get a Beacon response for individuals
       operationId: postIndividualsRequest
@@ -36,7 +36,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/requests/beaconRequestBody.json
+              $ref: ../../../../framework/json/requests/beaconRequestBody.json
         required: true
       responses:
         '200':
@@ -46,7 +46,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../../framework/json/responses/beaconErrorResponse.json
   /individuals/{id}:
     parameters:
       - $ref: '#/components/parameters/entryId'
@@ -64,7 +64,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../../framework/json/responses/beaconErrorResponse.json
     post:
       description: >-
         Get details about one individual, identified by its (unique) 'id'
@@ -75,7 +75,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/requests/beaconRequestBody.json
+              $ref: ../../../../framework/json/requests/beaconRequestBody.json
         required: true
       responses:
         '200':
@@ -85,7 +85,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../../framework/json/responses/beaconErrorResponse.json
   /individuals/{id}/g_variants:
     parameters:
       - $ref: '#/components/parameters/entryId'
@@ -108,7 +108,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../../framework/json/responses/beaconErrorResponse.json
     post:
       description: >-
         Get a *genomic variations* response for one individual, identified by
@@ -120,7 +120,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/requests/beaconRequestBody.json
+              $ref: ../../../../framework/json/requests/beaconRequestBody.json
         required: true
       responses:
         '200':
@@ -130,7 +130,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../../framework/json/responses/beaconErrorResponse.json
   /individuals/{id}/biosamples:
     parameters:
       - $ref: '#/components/parameters/entryId'
@@ -153,7 +153,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../../framework/json/responses/beaconErrorResponse.json
     post:
       description: >-
         Get a *biosamples* response for one individual, identified by its
@@ -165,7 +165,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/requests/beaconRequestBody.json
+              $ref: ../../../../framework/json/requests/beaconRequestBody.json
         required: true
       responses:
         '200':
@@ -175,7 +175,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../../framework/json/responses/beaconErrorResponse.json
   /individuals/filtering_terms:
     get:
       parameters:
@@ -191,13 +191,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconFilteringTermsResponse.json
+                $ref: ../../../../framework/json/responses/beaconFilteringTermsResponse.json
         default:
           description: An unsuccessful operation
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../../framework/json/responses/beaconErrorResponse.json
     post:
       description: Get the list of filtering terms that could be used with individuals.
       operationId: postIndividualsFilteringTerms
@@ -207,7 +207,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/requests/beaconRequestBody.json
+              $ref: ../../../../framework/json/requests/beaconRequestBody.json
         required: true
       responses:
         '200':
@@ -215,13 +215,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconFilteringTermsResponse.json
+                $ref: ../../../../framework/json/responses/beaconFilteringTermsResponse.json
         default:
           description: An unsuccessful operation
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../../framework/json/responses/beaconErrorResponse.json
 components:
   responses:
     ResultsOKResponse:
@@ -230,9 +230,9 @@ components:
         application/json:
           schema:
             oneOf:
-              - $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconBooleanResponse.json
-              - $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconCountResponse.json
-              - $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconResultsetsResponse.json
+              - $ref: ../../../../framework/json/responses/beaconBooleanResponse.json
+              - $ref: ../../../../framework/json/responses/beaconCountResponse.json
+              - $ref: ../../../../framework/json/responses/beaconResultsetsResponse.json
   parameters:
     requestedSchema:
       name: requestedSchema
@@ -247,17 +247,17 @@ components:
       name: skip
       in: query
       schema:
-        $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Skip
+        $ref: ../../../../framework/json/common/beaconCommonComponents.json#/$defs/Skip
     limit:
       name: limit
       in: query
       schema:
-        $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Limit
+        $ref: ../../../../framework/json/common/beaconCommonComponents.json#/$defs/Limit
     includeResultsetResponses:
       name: includeResultsetResponses
       in: query
       schema:
-        $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/IncludeResultsetResponses
+        $ref: ../../../../framework/json/common/beaconCommonComponents.json#/definitions/IncludeResultsetResponses
     entryId:
       name: id
       in: path

--- a/models/src/beacon-v2-default-model/runs/endpoints.yaml
+++ b/models/src/beacon-v2-default-model/runs/endpoints.yaml
@@ -26,7 +26,7 @@ paths:
         '200':
           $ref: '#/components/responses/ResultsOKResponse'
         default:
-          $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+          $ref: ../../../../framework/json/responses/beaconErrorResponse.json
     post:
       description: Get a Beacon response for experimental runs
       operationId: postRunsRequest
@@ -36,7 +36,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/requests/beaconRequestBody.json
+              $ref: ../../../../framework/json/requests/beaconRequestBody.json
         required: true
       responses:
         '200':
@@ -46,7 +46,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../../framework/json/responses/beaconErrorResponse.json
   /runs/{id}:
     parameters:
       - $ref: '#/components/parameters/entryId'
@@ -64,7 +64,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../../framework/json/responses/beaconErrorResponse.json
     post:
       description: >-
         Get details about one experimental run, identified by its (unique) 'id'
@@ -75,7 +75,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/requests/beaconRequestBody.json
+              $ref: ../../../../framework/json/requests/beaconRequestBody.json
         required: true
       responses:
         '200':
@@ -85,7 +85,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../../framework/json/responses/beaconErrorResponse.json
   /runs/{id}/g_variants:
     parameters:
       - $ref: '#/components/parameters/entryId'
@@ -108,7 +108,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../../framework/json/responses/beaconErrorResponse.json
     post:
       description: >-
         Get a *genomic variations* response for one experimental run, identified
@@ -120,7 +120,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/requests/beaconRequestBody.json
+              $ref: ../../../../framework/json/requests/beaconRequestBody.json
         required: true
       responses:
         '200':
@@ -130,7 +130,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../../framework/json/responses/beaconErrorResponse.json
   /runs/{id}/analyses:
     parameters:
       - $ref: '#/components/parameters/entryId'
@@ -153,7 +153,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../../framework/json/responses/beaconErrorResponse.json
     post:
       description: >-
         Get a *analyses* response for one experimental run, identified by its
@@ -165,7 +165,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/requests/beaconRequestBody.json
+              $ref: ../../../../framework/json/requests/beaconRequestBody.json
         required: true
       responses:
         '200':
@@ -175,7 +175,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconErrorResponse.json
+                $ref: ../../../../framework/json/responses/beaconErrorResponse.json
 components:
   responses:
     ResultsOKResponse:
@@ -184,9 +184,9 @@ components:
         application/json:
           schema:
             oneOf:
-              - $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconBooleanResponse.json
-              - $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconCountResponse.json
-              - $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/responses/beaconResultsetsResponse.json
+              - $ref: ../../../../framework/json/responses/beaconBooleanResponse.json
+              - $ref: ../../../../framework/json/responses/beaconCountResponse.json
+              - $ref: ../../../../framework/json/responses/beaconResultsetsResponse.json
   parameters:
     requestedSchema:
       name: requestedSchema
@@ -201,17 +201,17 @@ components:
       name: skip
       in: query
       schema:
-        $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Skip
+        $ref: ../../../../framework/json/common/beaconCommonComponents.json#/$defs/Skip
     limit:
       name: limit
       in: query
       schema:
-        $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/$defs/Limit
+        $ref: ../../../../framework/json/common/beaconCommonComponents.json#/$defs/Limit
     includeResultsetResponses:
       name: includeResultsetResponses
       in: query
       schema:
-        $ref: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/IncludeResultsetResponses
+        $ref: ../../../../framework/json/common/beaconCommonComponents.json#/definitions/IncludeResultsetResponses
     entryId:
       name: id
       in: path


### PR DESCRIPTION
Currently there is an inconsistent mix of absolute and relative $ref values in endpoints.yaml and endpoints.json (both in the same files and between YAML and JSON versions.

This is an attempt to harmonize all to relative - although it is not absolutely clear if this is the correct way to do it, depending on how endpoints files are instantiated ...