### PR TITLE
add VRS 2.0.1 to variant schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ This repository is a unified repository representing the different parts of the 
 * [models](models)
 * Beacon v2 Documentation
     - authoritive source already in this repository [`/docs`](docs)
-    - rendered version through [here](https://beacon-project.io/beacon-v2/) (alternative address is [docs.genomebeacons.org](https://docs.genomebeacons.org))
+    - rendered version through [docs.genomebeacons.org](https://docs.genomebeacons.org)
+    - Please note that edits to the documentation (and document generation) happens on/from the [website-docs](https://github.com/ga4gh-beacon/beacon-v2/tree/website-docs) branch!
 
 As with other schema projects, here we separate between the schema source files (in `src`; JSON-Schema written in YAML) and the generated versions for referencing. The current setup allows already the direct referencing of the generated JSON schemas. Examples:
 

--- a/bin/deref_schemas/individuals/defaultSchema.json
+++ b/bin/deref_schemas/individuals/defaultSchema.json
@@ -833,7 +833,7 @@
             ],
             "type": "string"
         },
-        "measures": {
+        "measurements": {
             "items": {
                 "$schema": "https://json-schema.org/draft/2020-12/schema",
                 "additionalProperties": true,

--- a/bin/deref_schemas/individuals/defaultSchema.yaml
+++ b/bin/deref_schemas/individuals/defaultSchema.yaml
@@ -590,7 +590,7 @@ properties:
       - XYY
       - OTHER_KARYOTYPE
     type: string
-  measures:
+  measurements:
     items:
       $schema: https://json-schema.org/draft/2020-12/schema
       additionalProperties: 1

--- a/bin/deref_schemas/obj/measures.yaml
+++ b/bin/deref_schemas/obj/measures.yaml
@@ -1,5 +1,5 @@
 ---
-measures:
+measurements:
   items:
     $schema: https://json-schema.org/draft/2020-12/schema
     additionalProperties: 1

--- a/docs/schemas-md/beacon_terms.md
+++ b/docs/schemas-md/beacon_terms.md
@@ -109,7 +109,7 @@
 * [locations](./obj/locations.md)
 * [measurements](./obj/measurements.md)
 * [measurementValue](./obj/measurementValue.md)
-* [measures](./obj/measures.md)
+* [measurements](./obj/measurements.md)
 * [memberId](./obj/memberId.md)
 * [members](./obj/members.md)
 * [modifiers](./obj/modifiers.md)

--- a/docs/schemas-md/individuals_defaultSchema.md
+++ b/docs/schemas-md/individuals_defaultSchema.md
@@ -8,7 +8,7 @@
 | [info](./obj/info.md) | Placeholder to allow the Beacon to return any additional information that is necessary or could be of interest in relation to the query or the entry returned. It is recommended to encapsulate additional informations in this attribute instead of directly adding attributes at the same level than the others in order to avoid collision in the names of attributes in future versions of the specification. | object | NA | NA | NA|
 | [interventionsOrProcedures](./obj/interventionsOrProcedures.md) | Class describing a clinical procedure or intervention. Provenance: GA4GH Phenopackets v2 `Procedure` | array | [ageAtProcedure](./obj/ageAtProcedure.md), [bodySite](./obj/bodySite.md), [dateOfProcedure](./obj/dateOfProcedure.md), [procedureCode](./obj/procedureCode.md) | NA | NA|
 | [karyotypicSex](./obj/karyotypicSex.md) | The chromosomal sex of an individual represented from a selection of options. | string | NA | NA | UNKNOWN_KARYOTYPE, XX, XY, XO, XXY, XXX, XXYY, XXXY, XXXX, XYY, OTHER_KARYOTYPE|
-| [measures](./obj/measures.md) | Definition of a measurement class. Provenance: GA4GH Phenopackets v2 `Measurement` | array | [assayCode](./obj/assayCode.md), [date](./obj/date.md), [measurementValue](./obj/measurementValue.md), [notes](./obj/notes.md), [observationMoment](./obj/observationMoment.md), [procedure](./obj/procedure.md) | NA | NA|
+| [measurements](./obj/measurements.md) | Definition of a measurement class. Provenance: GA4GH Phenopackets v2 `Measurement` | array | [assayCode](./obj/assayCode.md), [date](./obj/date.md), [measurementValue](./obj/measurementValue.md), [notes](./obj/notes.md), [observationMoment](./obj/observationMoment.md), [procedure](./obj/procedure.md) | NA | NA|
 | [pedigrees](./obj/pedigrees.md) | Pedigree studies in which the individual is part of. | array | [disease](./obj/disease.md), [id](./obj/id.md), [members](./obj/members.md), [numSubjects](./obj/numSubjects.md) | NA | NA|
 | [phenotypicFeatures](./obj/phenotypicFeatures.md) | Used to describe a phenotype that characterizes the subject or biosample. | array | [evidence](./obj/evidence.md), [excluded](./obj/excluded.md), [featureType](./obj/featureType.md), [modifiers](./obj/modifiers.md), [notes](./obj/notes.md), [onset](./obj/onset.md), [resolution](./obj/resolution.md), [severity](./obj/severity.md) | NA | NA|
 | [sex](./obj/sex.md) | Sex of the individual. Value from NCIT General Qualifier (NCIT:C27993): 'unknown' (not assessed or not available) (NCIT:C17998), 'female' (NCIT:C16576), or 'male', (NCIT:C20197). | object | [id](./obj/id.md), [label](./obj/label.md) | `[{"id": "NCIT:C16576", "label": "female"}, {"id": "NCIT:C20197", "label": "male"}, {"id": "NCIT:C1799", "label": "unknown"}]` | NA|
@@ -65,7 +65,7 @@ These are examples extracted directly from the [GitHub repository](https://githu
 	        "label": "Slovenia"
 	    },
 	    "id": "Ind001",
-	    "measures": [
+	    "measurements": [
 	        {
 	            "assayCode": {
 	                "id": "LOINC:26515-7",

--- a/docs/schemas-md/obj/measures.md
+++ b/docs/schemas-md/obj/measures.md
@@ -1,3 +1,3 @@
 |Term | Description | Type | Properties | Example | Enum|
 | ---| ---| ---| ---| ---| --- |
-| measures | Definition of a measurement class. Provenance: GA4GH Phenopackets v2 `Measurement` | array | [assayCode](./assayCode.md), [date](./date.md), [measurementValue](./measurementValue.md), [notes](./notes.md), [observationMoment](./observationMoment.md), [procedure](./procedure.md) | NA | NA|
+| measurements | Definition of a measurement class. Provenance: GA4GH Phenopackets v2 `Measurement` | array | [assayCode](./assayCode.md), [date](./date.md), [measurementValue](./measurementValue.md), [notes](./notes.md), [observationMoment](./observationMoment.md), [procedure](./procedure.md) | NA | NA|

--- a/framework/json/configuration/entryTypeDefinition.json
+++ b/framework/json/configuration/entryTypeDefinition.json
@@ -8,10 +8,10 @@
         },
         "aCollectionOf": {
             "description": "If the entry type is a collection of other entry types, (e.g. a Dataset is a collection of Records), then this attribute must list the entry types that could be included. One collection type could be defined as included more than one entry type (e.g. a Dataset could include Individuals or Genomic Variants), in such cases the entries are alternative, meaning that a given instance of this entry type could be of only one of the types (e.g. a given Dataset contains Individuals, while another Dataset could contain Genomic Variants, but not both at once).",
-            "type": "array",
             "items": {
                 "$ref": "../common/basicElement.json"
-            }
+            },
+            "type": "array"
         },
         "additionallySupportedSchemas": {
             "description": "List of additional schemas that could be used for this concept in this instance of Beacon.",

--- a/models/json/beacon-v2-default-model/cohorts/defaultSchema.json
+++ b/models/json/beacon-v2-default-model/cohorts/defaultSchema.json
@@ -273,6 +273,9 @@
             "description": "Inclusion criteria used for defining the cohort. It is assumed that all cohort participants will match such criteria.",
             "type": "object"
         },
+        "info": {
+            "$ref": "../common/info.json"
+        },
         "name": {
             "description": "Name of the cohort. For `user-defined` this field could be generated upon the query, e.g. a value that is a concatenationor some representation of the user query.",
             "examples": [

--- a/models/json/beacon-v2-default-model/common/info.json
+++ b/models/json/beacon-v2-default-model/common/info.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "Placeholder to allow the Beacon models to return additional information. It is recommended to encapsulate additional informations in this attribute instead of directly adding attributes at the schema's root level in order to avoid collision in the names of attributes in future versions of the specification.",
+    "title": "Info",
+    "type": "object"
+}

--- a/models/json/beacon-v2-default-model/common/timeElement.json
+++ b/models/json/beacon-v2-default-model/common/timeElement.json
@@ -23,5 +23,8 @@
         }
     ],
     "title": "TimeElement",
-    "type": "object"
+    "type": [
+        "object",
+        "string"
+    ]
 }

--- a/models/json/beacon-v2-default-model/genomicVariations/defaultSchema.json
+++ b/models/json/beacon-v2-default-model/genomicVariations/defaultSchema.json
@@ -540,6 +540,9 @@
         "identifiers": {
             "$ref": "#/$defs/Identifiers"
         },
+        "info": {
+            "$ref": "../common/info.json"
+        },
         "molecularAttributes": {
             "$ref": "#/$defs/MolecularAttributes"
         },

--- a/models/json/beacon-v2-default-model/genomicVariations/defaultSchema.json
+++ b/models/json/beacon-v2-default-model/genomicVariations/defaultSchema.json
@@ -560,6 +560,9 @@
         "variation": {
             "oneOf": [
                 {
+                    "$ref": "https://w3id.org/ga4gh/schema/vrs/2.0.1/json/Variation"
+                },
+                {
                     "$ref": "https://w3id.org/ga4gh/schema/vrs/1.3/vrs.json#/definitions/MolecularVariation"
                 },
                 {

--- a/models/json/beacon-v2-default-model/individuals/defaultSchema.json
+++ b/models/json/beacon-v2-default-model/individuals/defaultSchema.json
@@ -43,7 +43,7 @@
             "$ref": "../common/commonDefinitions.json#/$defs/KaryotypicSex",
             "description": "The chromosomal sex of an individual represented from a selection of options."
         },
-        "measures": {
+        "measurements": {
             "items": {
                 "$ref": "../common/measurement.json"
             },

--- a/models/json/beacon-v2-default-model/individuals/defaultSchema.json
+++ b/models/json/beacon-v2-default-model/individuals/defaultSchema.json
@@ -43,7 +43,7 @@
             "$ref": "../common/commonDefinitions.json#/$defs/KaryotypicSex",
             "description": "The chromosomal sex of an individual represented from a selection of options."
         },
-        "measurements": {
+        "measures": {
             "items": {
                 "$ref": "../common/measurement.json"
             },

--- a/models/json/beacon-v2-default-model/individuals/examples/individual-MID-example.json
+++ b/models/json/beacon-v2-default-model/individuals/examples/individual-MID-example.json
@@ -32,7 +32,7 @@
         "label": "Slovenia"
     },
     "id": "Ind001",
-    "measures": [
+    "measurements": [
         {
             "assayCode": {
                 "id": "LOINC:26515-7",

--- a/models/src/beacon-v2-default-model/biosamples/defaultSchema.yaml
+++ b/models/src/beacon-v2-default-model/biosamples/defaultSchema.yaml
@@ -161,6 +161,7 @@ properties:
     example: {}
   info:
     $ref: ../common/info.yaml
+
 required:
   - id
   - biosampleStatus

--- a/models/src/beacon-v2-default-model/cohorts/defaultSchema.yaml
+++ b/models/src/beacon-v2-default-model/cohorts/defaultSchema.yaml
@@ -75,6 +75,9 @@ properties:
     type: array
     items:
       $ref: '#/$defs/CollectionEvent'
+  info:
+    $ref: ../common/info.yaml
+
 $defs:
   CollectionEvent:
     description: TBD

--- a/models/src/beacon-v2-default-model/common/info.yaml
+++ b/models/src/beacon-v2-default-model/common/info.yaml
@@ -1,0 +1,9 @@
+$schema: https://json-schema.org/draft/2020-12/schema
+title: Info
+description: >-
+  Placeholder to allow the Beacon models to return additional information.
+  It is recommended to encapsulate additional informations in this attribute
+  instead of directly adding attributes at the schema's root level in
+  order to avoid collision in the names of attributes in future versions of
+  the specification.
+type: object

--- a/models/src/beacon-v2-default-model/common/timeElement.yaml
+++ b/models/src/beacon-v2-default-model/common/timeElement.yaml
@@ -1,8 +1,11 @@
 $schema: https://json-schema.org/draft/2020-12/schema
 title: TimeElement
-description: Definition of a wrapper for various time descriptors. This follows the
+description: |-
+  Definition of a wrapper for various time descriptors. This follows the
   Phenopackets structure https://github.com/phenopackets/phenopacket-schema/blob/v2/docs/time-element.rst
-type: object
+type:
+  - object
+  - string
 $comments: If using an ontology class the use of NCIT Age Group ontology term (NCIT:C20587)
   descendants is recommended.
 oneOf:

--- a/models/src/beacon-v2-default-model/datasets/defaultSchema.yaml
+++ b/models/src/beacon-v2-default-model/datasets/defaultSchema.yaml
@@ -39,11 +39,12 @@ properties:
       3986 format).
     examples:
       - https://example.org/wiki/Main_Page
-  info:
-    $ref: ../common/info.yaml
   dataUseConditions:
     description: Data use conditions applying to this dataset.
     $ref: ../common/dataUseConditions.yaml
+  info:
+    $ref: ../common/info.yaml
+
 required:
   - id
   - name

--- a/models/src/beacon-v2-default-model/genomicVariations/defaultSchema.yaml
+++ b/models/src/beacon-v2-default-model/genomicVariations/defaultSchema.yaml
@@ -42,6 +42,9 @@ properties:
     type: array
     items:
       $ref: '#/$defs/FrequencyInPopulations'
+  info:
+    $ref: ../common/info.yaml
+
 $defs:
   LegacyVariation:
     type: object

--- a/models/src/beacon-v2-default-model/genomicVariations/defaultSchema.yaml
+++ b/models/src/beacon-v2-default-model/genomicVariations/defaultSchema.yaml
@@ -10,6 +10,7 @@ required:
 properties:
   variation:
     oneOf:
+      - $ref: https://w3id.org/ga4gh/schema/vrs/2.0.1/json/Variation
       - $ref: https://w3id.org/ga4gh/schema/vrs/1.3/vrs.json#/definitions/MolecularVariation
       - $ref: https://w3id.org/ga4gh/schema/vrs/1.3/vrs.json#/definitions/SystemicVariation
       - $ref: '#/$defs/LegacyVariation'

--- a/models/src/beacon-v2-default-model/individuals/defaultSchema.yaml
+++ b/models/src/beacon-v2-default-model/individuals/defaultSchema.yaml
@@ -53,7 +53,7 @@ properties:
     type: array
     items:
       $ref: ../common/procedure.yaml
-  measures:
+  measurements:
     type: array
     items:
       $ref: ../common/measurement.yaml

--- a/models/src/beacon-v2-default-model/individuals/defaultSchema.yaml
+++ b/models/src/beacon-v2-default-model/individuals/defaultSchema.yaml
@@ -53,7 +53,7 @@ properties:
     type: array
     items:
       $ref: ../common/procedure.yaml
-  measurements:
+  measures:
     type: array
     items:
       $ref: ../common/measurement.yaml

--- a/models/src/beacon-v2-default-model/individuals/examples/individual-MID-example.yaml
+++ b/models/src/beacon-v2-default-model/individuals/examples/individual-MID-example.yaml
@@ -24,7 +24,7 @@ diseases:
     stage:
       id: OGMS:0000119
       label: acute onset
-measures:
+measurements:
   - assayCode:
       id: LOINC:26515-7
       label: Platelets [#/volume] in Blood


### PR DESCRIPTION
This adds the VRS 2 (latest 2.0.1 version) as an option to the default Genomic Variation schema, using the permanent w3id link resolver.

This change should get into "urgent fixes" since

* it is non-breaking since it doesn't remove older versions
* it will allow Beacon implementers to go ahead with the current version of VRS