### PR TITLE
adding the VRS v2 option to the variant schema

### DIFF
--- a/models/json/beacon-v2-default-model/genomicVariations/defaultSchema.json
+++ b/models/json/beacon-v2-default-model/genomicVariations/defaultSchema.json
@@ -557,6 +557,9 @@
         "variation": {
             "oneOf": [
                 {
+                    "$ref": "https://w3id.org/ga4gh/schema/vrs/2.0.1/json/Variation"
+                },
+                {
                     "$ref": "https://w3id.org/ga4gh/schema/vrs/1.3/vrs.json#/definitions/MolecularVariation"
                 },
                 {

--- a/models/src/beacon-v2-default-model/genomicVariations/defaultSchema.yaml
+++ b/models/src/beacon-v2-default-model/genomicVariations/defaultSchema.yaml
@@ -10,6 +10,7 @@ required:
 properties:
   variation:
     oneOf:
+      - $ref: https://w3id.org/ga4gh/schema/vrs/2.0.1/json/Variation
       - $ref: https://w3id.org/ga4gh/schema/vrs/1.3/vrs.json#/definitions/MolecularVariation
       - $ref: https://w3id.org/ga4gh/schema/vrs/1.3/vrs.json#/definitions/SystemicVariation
       - $ref: '#/$defs/LegacyVariation'


### PR DESCRIPTION
Discussion started from https://github.com/ga4gh-beacon/beacon-v2/pull/232 ; fresh version against `develop`