### PR TITLE
src -> json cosmetics fix

### DIFF
--- a/framework/json/configuration/entryTypeDefinition.json
+++ b/framework/json/configuration/entryTypeDefinition.json
@@ -8,10 +8,10 @@
         },
         "aCollectionOf": {
             "description": "If the entry type is a collection of other entry types, (e.g. a Dataset is a collection of Records), then this attribute must list the entry types that could be included. One collection type could be defined as included more than one entry type (e.g. a Dataset could include Individuals or Genomic Variants), in such cases the entries are alternative, meaning that a given instance of this entry type could be of only one of the types (e.g. a given Dataset contains Individuals, while another Dataset could contain Genomic Variants, but not both at once).",
-            "type": "array",
             "items": {
                 "$ref": "../common/basicElement.json"
-            }
+            },
+            "type": "array"
         },
         "additionallySupportedSchemas": {
             "description": "List of additional schemas that could be used for this concept in this instance of Beacon.",

--- a/framework/json/responses/sections/beaconInfoResults.json
+++ b/framework/json/responses/sections/beaconInfoResults.json
@@ -61,7 +61,7 @@
             "description": "The date/time the Beacon was created (ISO 8601 format).",
             "examples": [
                 "2014-07-19",
-                "2017-01-17 20:33:40"
+                "2017-01-17 20:33:40+00:00"
             ],
             "type": "string"
         },
@@ -100,7 +100,7 @@
             "description": "The time the Beacon was updated in (ISO 8601 format).",
             "examples": [
                 "2014-07-19",
-                "2017-01-17 20:33:40"
+                "2017-01-17 20:33:40+00:00"
             ],
             "type": "string"
         },


### PR DESCRIPTION
This just fixes 2 instances were the JSON version diverged from the source; one with incomplete date-time example and one where order & white space were different from the programmatic conversion.