### PR TITLE
post examples fix

### DIFF
--- a/docs/variant-queries.md
+++ b/docs/variant-queries.md
@@ -59,14 +59,15 @@ in the _EIF4A1_ eukaryotic translation initiation factor 4A1.
 	                "start": [7577120],
 	                "referenceBases": "G",
 	                "alternateBases": "A"
-		    	}
+		    	},
+	            "requestedGranularity": "record",
+	            "pagination": {
+	                "skip": 0,
+	                "limit": 5
+	            }
 	        }
-	    },
-	    "requestedGranularity": "record",
-	    "pagination": {
-	        "skip": 0,
-	        "limit": 5
 	    }
+
 	}
 	```
 
@@ -151,12 +152,12 @@ parameters.
 	                "start": [ 7572837 ],
 	                "end": [ 7578641 ]
 		    	}
+	        },
+	        "requestedGranularity": "record",
+	        "pagination": {
+	            "skip": 0,
+	            "limit": 5
 	        }
-	    },
-	    "requestedGranularity": "record",
-	    "pagination": {
-	        "skip": 0,
-	        "limit": 5
 	    }
 	}
 	```
@@ -214,12 +215,12 @@ a positional translation is being applied.
 	                "geneId": "EIF4A1",
 	                "variantType": "EFO:0030067"
 		    	}
+	        },
+	        "requestedGranularity": "record",
+	        "pagination": {
+	            "skip": 0,
+	            "limit": 5
 	        }
-	    },
-	    "requestedGranularity": "record",
-	    "pagination": {
-	        "skip": 0,
-	        "limit": 5
 	    }
 	}
 	```
@@ -297,12 +298,12 @@ larger than approx. 5Mb (operational definitions of focality vary between 1 and 
 	                "end": [ 7669607, 10000000 ],
 	                "variantType": "DEL"
 		    	}
+	        },
+	        "requestedGranularity": "record",
+	        "pagination": {
+	            "skip": 0,
+	            "limit": 5
 	        }
-	    },
-	    "requestedGranularity": "record",
-	    "pagination": {
-	        "skip": 0,
-	        "limit": 5
 	    }
 	}
 	```


### PR DESCRIPTION
POST examples erroneously put "pagination" and "requestedGranularity" properties in the request root (should be inside the "query"). https://github.com/ga4gh-beacon/beacon-v2/blob/c6558bf2e6494df3905f7b2df66e903dfe509500/framework/json/requests/beaconRequestBody.json#L12