### PR TITLE
Adding "excluded" property to "OntologyFilter"

### DIFF
--- a/framework/json/requests/filteringTerms.json
+++ b/framework/json/requests/filteringTerms.json
@@ -45,11 +45,6 @@
         "CustomFilter": {
             "description": "Filter results to include records that contain a custom term defined by this Beacon.",
             "properties": {
-                "excluded": {
-                    "default": false,
-                    "description": "See `excluded` in `OntologyFilter`.",
-                    "type": "boolean"
-                },
                 "id": {
                     "description": "Custom filter terms should contain a unique identifier.",
                     "example": "demographic.ethnicity:asian",
@@ -86,7 +81,7 @@
             "properties": {
                 "excluded": {
                     "default": false,
-                    "description": "Flag to indicate whether the filtering term was observed or not. The default is `false`, _i.e._ will be selected for **existence** of the term. The use of `true` should select for a **negation** of the term, _i.e._ an indication that the condition has been evaluated & excluded (c.f. the the description in Phenopackets  as \"...to indicate that the phenotype was looked for, but found to be absent.\")",
+                    "description": "Property to indicate whether the filtering term was observed or not. The default is `false`, _i.e._ will be selected for **existence** of the term. The use of `true` should select for a **negation** of the term, _i.e._ an indication that the condition has been evaluated & excluded (c.f. the the description in Phenopackets  as \"...to indicate that the phenotype was looked for, but found to be absent.\") Note: The `excluded` property is specific for `OntologyFilter` instances since e.g. `AlphanumericFilter` can implement the functionality via operators (`!`) and `CustomFilter` instances can be designed for exclusion.",
                     "type": "boolean"
                 },
                 "id": {

--- a/framework/json/requests/filteringTerms.json
+++ b/framework/json/requests/filteringTerms.json
@@ -81,7 +81,7 @@
             "properties": {
                 "excluded": {
                     "default": false,
-                    "description": "Property to indicate whether the filtering term was observed or not. The default is `false`, _i.e._ will be selected for **existence** of the term. The use of `true` should select for a **negation** of the term, _i.e._ an indication that the condition has been evaluated & excluded (c.f. the the description in Phenopackets  as \"...to indicate that the phenotype was looked for, but found to be absent.\") Note: The `excluded` property is specific for `OntologyFilter` instances since e.g. `AlphanumericFilter` can implement the functionality via operators (`!`) and `CustomFilter` instances can be designed for exclusion.",
+                    "description": "Field to indicate whether the filtering term was observed or not. The default is `false`, _i.e._ selects for **existence** of the term or value (c.f. the the description in Phenopackets  as \"...to indicate that the phenotype was looked for, but found to be absent.\")\nThe use of `true` select for an explicit **negation** of the term, _i.e._ only returns a match if the \n* queried property has an excluded property  * the value of the `excluded` field in the is set to `true`\nA use of `excluded: false` has no operational effect and is equivalent to omitting the filter.\nNote: The `excluded` field is specific for `OntologyFilter` instances since e.g. `AlphanumericFilter` can implement the functionality via operators (`!`) and `CustomFilter` instances can be specifically designed towards exclusion.",
                     "type": "boolean"
                 },
                 "id": {

--- a/framework/json/requests/filteringTerms.json
+++ b/framework/json/requests/filteringTerms.json
@@ -45,6 +45,11 @@
         "CustomFilter": {
             "description": "Filter results to include records that contain a custom term defined by this Beacon.",
             "properties": {
+                "excluded": {
+                    "default": false,
+                    "description": "See `excluded` in `OntologyFilter`.",
+                    "type": "boolean"
+                },
                 "id": {
                     "description": "Custom filter terms should contain a unique identifier.",
                     "example": "demographic.ethnicity:asian",
@@ -79,6 +84,11 @@
         "OntologyFilter": {
             "description": "Filter results to include records that contain a specific ontology term.",
             "properties": {
+                "excluded": {
+                    "default": false,
+                    "description": "Flag to indicate whether the filtering term was observed or not. The default is `false`, _i.e._ will be selected for **existence** of the term. The use of `true` should select for a **negation** of the term, _i.e._ an indication that the condition has been evaluated & excluded (c.f. the the description in Phenopackets  as \"...to indicate that the phenotype was looked for, but found to be absent.\")",
+                    "type": "boolean"
+                },
                 "id": {
                     "description": "Term ID to be queried, using CURIE syntax where possible.",
                     "example": "HP:0002664",

--- a/framework/src/requests/filteringTerms.yaml
+++ b/framework/src/requests/filteringTerms.yaml
@@ -56,8 +56,19 @@ $defs:
           * queried property has an excluded property 
           * the value of the `excluded` field in the is set to `true`
 
-          A use of `excluded: false` has no operational effect and is equivalent
-          to omitting the filter.
+          A use of `excluded: false` avoids the match of positively negated
+          values.
+
+          Implementations MUST ensure that the `excluded` property is upported for
+          target property or provide appropriate handling of the request. For
+          example, to implement the default `excluded: false` queries in MongoDB
+          a request could use the `$not` operator to exclude
+          both documents with the term and documents that do not have the 
+          `thisField.excluded` property and the ones that have it set to `false`
+
+          `db.test.find({"thisFieldexcluded":{$ne:true}})`
+
+          ... as the default.
 
           Note: The `excluded` field is specific for `OntologyFilter` instances
           since e.g. `AlphanumericFilter` can implement the functionality via

--- a/framework/src/requests/filteringTerms.yaml
+++ b/framework/src/requests/filteringTerms.yaml
@@ -45,12 +45,15 @@ $defs:
           of 'high', 'medium' and 'low' similarity.
       excluded:
         description: >-
-          Flag to indicate whether the filtering term was observed or not. The
+          Property to indicate whether the filtering term was observed or not. The
           default is `false`, _i.e._ will be selected for **existence** of the term.
           The use of `true` should select for a **negation** of the term, _i.e._
           an indication that the condition has been evaluated & excluded (c.f.
           the the description in Phenopackets  as "...to indicate that the phenotype
           was looked for, but found to be absent.")
+          Note: The `excluded` property is specific for `OntologyFilter` instances
+          since e.g. `AlphanumericFilter` can implement the functionality via
+          operators (`!`) and `CustomFilter` instances can be designed for exclusion.
         type: boolean
         default: false
       scope:
@@ -84,11 +87,11 @@ $defs:
         type: string
         enum:
           - '='
-          - <
+          - '<'
           - '>'
           - '!'
           - '>='
-          - <=
+          - '<='
         description: Defines how the value relates to the field `id`.
         default: '='
         example: '>'
@@ -118,11 +121,6 @@ $defs:
         type: string
         description: Custom filter terms should contain a unique identifier.
         example: demographic.ethnicity:asian
-      excluded:
-        description: >-
-          See `excluded` in `OntologyFilter`.
-        type: boolean
-        default: false
       scope:
         type: string
         description: |-

--- a/framework/src/requests/filteringTerms.yaml
+++ b/framework/src/requests/filteringTerms.yaml
@@ -45,15 +45,24 @@ $defs:
           of 'high', 'medium' and 'low' similarity.
       excluded:
         description: >-
-          Property to indicate whether the filtering term was observed or not. The
-          default is `false`, _i.e._ will be selected for **existence** of the term.
-          The use of `true` should select for a **negation** of the term, _i.e._
-          an indication that the condition has been evaluated & excluded (c.f.
-          the the description in Phenopackets  as "...to indicate that the phenotype
-          was looked for, but found to be absent.")
-          Note: The `excluded` property is specific for `OntologyFilter` instances
+          Field to indicate whether the filtering term was observed or not. The
+          default is `false`, _i.e._ selects for **existence** of the term or value
+          (c.f. the the description in Phenopackets  as "...to indicate that the
+          phenotype was looked for, but found to be absent.")
+          
+          The use of `true` select for an explicit **negation** of the term, _i.e._
+          only returns a match if the 
+          
+          * queried property has an excluded property 
+          * the value of the `excluded` field in the is set to `true`
+
+          A use of `excluded: false` has no operational effect and is equivalent
+          to omitting the filter.
+
+          Note: The `excluded` field is specific for `OntologyFilter` instances
           since e.g. `AlphanumericFilter` can implement the functionality via
-          operators (`!`) and `CustomFilter` instances can be designed for exclusion.
+          operators (`!`) and `CustomFilter` instances can be specifically designed
+          towards exclusion.
         type: boolean
         default: false
       scope:

--- a/framework/src/requests/filteringTerms.yaml
+++ b/framework/src/requests/filteringTerms.yaml
@@ -43,6 +43,16 @@ $defs:
           exactly, but do match to a certain degree of similarity. The Beacon defines
           the semantic similarity model implemented and how to apply the thresholds
           of 'high', 'medium' and 'low' similarity.
+      excluded:
+        description: >-
+          Flag to indicate whether the filtering term was observed or not. The
+          default is `false`, _i.e._ will be selected for **existence** of the term.
+          The use of `true` should select for a **negation** of the term, _i.e._
+          an indication that the condition has been evaluated & excluded (c.f.
+          the the description in Phenopackets  as "...to indicate that the phenotype
+          was looked for, but found to be absent.")
+        type: boolean
+        default: false
       scope:
         type: string
         description: |-
@@ -108,6 +118,11 @@ $defs:
         type: string
         description: Custom filter terms should contain a unique identifier.
         example: demographic.ethnicity:asian
+      excluded:
+        description: >-
+          See `excluded` in `OntologyFilter`.
+        type: boolean
+        default: false
       scope:
         type: string
         description: |-


### PR DESCRIPTION
This PR adds an "excluded" property to "OntologyFilter" and "CustomFilter". See discussion at  https://github.com/ga4gh-beacon/beacon-v2/issues/63