### PR TITLE
Filters support for the 'OR' groups

### DIFF
--- a/framework/json/requests/filteringTerms.json
+++ b/framework/json/requests/filteringTerms.json
@@ -64,7 +64,7 @@
             "type": "object"
         },
         "FilteringTermsGroupsInRequest": {
-            "description": "Filtering terms unions groups. A single filtering term is considered as a union group with just one filter. In other words this value may be either a filter or an array of filters that form a union group ('OR').",
+            "description": "Either a single filter or the 'AND' (CNF) group of filters.",
             "examples": [
                 { "id": "NCIT:C20197" },
                 [
@@ -145,7 +145,11 @@
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "additionalProperties": true,
-    "description": "Filtering terms are the main means to select subsets of records from a Beacon response. While the name implies the application to a generated response, in practice implementations may apply them at the query stage. Note: In the processing of Beacon v2.0 requests multiple filters are assumed to be chained by the logical AND operator.",
+    "description": "Filtering terms are the main means to select subsets of records from a Beacon response. While the name implies the application to a generated response, in practice implementations may apply them at the query stage. Note: While multiple filters are assumed to be chained by the logical AND operator, if any of filters is a group of filters itself the filters are chained by the logical OR operator.",
+    "examples": [
+                    [ { "id": "NCIT:C20197" } ],
+                    [ [ {"id": "MONDO:0004643"} ], [{"id": "MONDO:0020334"} ] ]
+    ],
     "items": {
         "$ref": "#/$defs/FilteringTermsGroupsInRequest"
     },

--- a/framework/json/requests/filteringTerms.json
+++ b/framework/json/requests/filteringTerms.json
@@ -71,12 +71,12 @@
                     {
                         "id": "Weight",
                         "operator": ">",
-                        "value": "80"
+                        "value": 80
                     },
                     {
                         "id": "BMI",
                         "operator": ">",
-                        "value": "25"
+                        "value": 25
                     }
                 ]
             ],

--- a/framework/json/requests/filteringTerms.json
+++ b/framework/json/requests/filteringTerms.json
@@ -64,7 +64,22 @@
             "type": "object"
         },
         "FilteringTermsGroupsInRequest": {
-            "description": "Filtering terms unions groups. A single filtering term is considered as a union group with just one filter.",
+            "description": "Filtering terms unions groups. A single filtering term is considered as a union group with just one filter. In other words this value may be either a filter or an array of filters that form a union group ('OR').",
+            "examples": [
+                { "id": "NCIT:C20197" },
+                [
+                    {
+                        "id": "Weight",
+                        "operator": ">",
+                        "value": "80"
+                    },
+                    {
+                        "id": "BMI",
+                        "operator": ">",
+                        "value": "25"
+                    }
+                ]
+            ],
             "oneOf": [
                 {
                     "$ref": "#/$defs/FilteringTermInRequest" 

--- a/framework/json/requests/filteringTerms.json
+++ b/framework/json/requests/filteringTerms.json
@@ -63,6 +63,20 @@
             ],
             "type": "object"
         },
+        "FilteringTermsGroupsInRequest": {
+            "description": "Filtering terms unions groups. A single filtering term is considered as a union group with just one filter.",
+            "oneOf": [
+                {
+                    "$ref": "#/$defs/FilteringTermInRequest" 
+                },
+                {
+                    "items": {
+                        "$ref": "#/$defs/FilteringTermInRequest"
+                    },
+                    "type": "array"
+                }
+            ]
+        },
         "FilteringTermInRequest": {
             "anyOf": [
                 {
@@ -118,7 +132,7 @@
     "additionalProperties": true,
     "description": "Filtering terms are the main means to select subsets of records from a Beacon response. While the name implies the application to a generated response, in practice implementations may apply them at the query stage. Note: In the processing of Beacon v2.0 requests multiple filters are assumed to be chained by the logical AND operator.",
     "items": {
-        "$ref": "#/$defs/FilteringTermInRequest"
+        "$ref": "#/$defs/FilteringTermsGroupsInRequest"
     },
     "title": "Filtering Term Element",
     "type": "array"

--- a/framework/src/requests/filteringTerms.yaml
+++ b/framework/src/requests/filteringTerms.yaml
@@ -4,15 +4,14 @@ description: >-
   Filtering terms are the main means to select subsets of records from a Beacon
   response. While the name implies the application to a generated response, in
   practice implementations may apply them at the query stage.
-  Note: In the processing of Beacon v2.0 requests multiple filters are assumed
-  to be chained by the logical AND operator.
+  Note: While multiple filters are assumed to be chained by the logical AND operator, 
+  if any of filters is a group of filters itself the filters are chained by the logical OR operator.
 type: array
 items:
   $ref: '#/$defs/FilteringTermsGroupsInRequest'
 $defs:
   FilteringTermsGroupsInRequest:
-    description: Filtering terms unions groups. A single filtering term is considered as a union group with just one filter.
-      In other words this value may be either a filter or an array of filters that form a union group ('OR').
+    description: Either a single filter or the 'AND' (CNF) group of filters
     oneOf:
       - $ref: '#/$defs/FilteringTermInRequest'
       - - $ref: '#/$defs/FilteringTermInRequest'

--- a/framework/src/requests/filteringTerms.yaml
+++ b/framework/src/requests/filteringTerms.yaml
@@ -8,13 +8,29 @@ description: >-
   to be chained by the logical AND operator.
 type: array
 items:
-  $ref: '#/$defs/FilteringTermInRequest'
+  $ref: '#/$defs/FilteringTermsGroupsInRequest'
 $defs:
+  FilteringTermsGroupsInRequest:
+    description: Filtering terms unions groups. A single filtering term is considered as a union group with just one filter.
+      In other words this value may be either a filter or an array of filters that form a union group ('OR').
+    oneOf:
+      - $ref: '#/$defs/FilteringTermInRequest'
+      - - $ref: '#/$defs/FilteringTermInRequest'
+    examples:
+      - id: 'NCIT:C20197'
+      - - id: 'Weight'
+          operator: '>',
+          value: 80
+        - id: 'BMI'
+          operator: '>',
+          value: 25
+
   FilteringTermInRequest:
     anyOf:
       - $ref: '#/$defs/OntologyFilter'
       - $ref: '#/$defs/AlphanumericFilter'
       - $ref: '#/$defs/CustomFilter'  
+
   OntologyFilter:
     type: object
     description: Filter results to include records that contain a specific ontology


### PR DESCRIPTION
In addition to the Beacon v2.0 filters that was implicitly intersections ('AND') provide 'OR' groups:
```
[
  filter1,
  filter2,
  filter3
]
```
where filters __filter1, filter2, filter3__ are implicitly 'AND'
```
[
  filter1,
  [
    filter2,
    filter3
  ]
]
```
where filters are grouped as __filter1 AND (filter2 OR filter3)__.